### PR TITLE
Add docker-compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.7'
+volumes:
+  mysql-data:
+services:
+  mysql:
+    image: mysql:5.6
+    environment:
+      MYSQL_ROOT_PASSWORD: unsecure
+      MYSQL_DATABASE: user-service_dev
+    volumes:
+      - mysql-data:/var/lib/mysql
+  web:
+    build: .
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mysql
+    environment:
+      USERSERVICE_PORT: 8080
+      NODE_ENV: development
+      DB_HOST: mysql
+      DB_PORT: 3306
+      DB_USER: root
+      DB_PASSWORD: unsecure
+      DB_NAME: user-service
+      SESSION_SECRET: unsecure


### PR DESCRIPTION
This allows local development without having a single MySQL instance running on the host – instead it's containerised and available as `mysql` inside the Compose network.