### PR TITLE
Optimize the amount of intermediate Docker layers and use transient yarn cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: trusty
 sudo: required
+language: generic
 
 jobs:
   include:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
 FROM node:10.8-alpine
 
+ENV YARN_CACHE_FOLDER=/dev/shm/yarn-cache
+
 WORKDIR /app
 
 RUN apk --no-cache add --virtual native-deps \
   g++ gcc libgcc libstdc++ linux-headers make python \
   chromium chromium-chromedriver
 
-RUN npm install --global yarn@1.7.0
+RUN npm install --global yarn@1.10.1
 
 COPY yarn.lock package.json /app/
-RUN yarn --dev
+RUN yarn --dev --frozen-lockfile
 
 COPY . /app/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,16 @@
 FROM node:10.8-alpine
 
+WORKDIR /app
+
 RUN apk --no-cache add --virtual native-deps \
   g++ gcc libgcc libstdc++ linux-headers make python \
   chromium chromium-chromedriver
 
 RUN npm install --global yarn@1.7.0
 
-WORKDIR /app
-COPY yarn.lock ./
-COPY package.json ./
+COPY yarn.lock package.json /app/
 RUN yarn --dev
 
-COPY knexfile.ts ./
-COPY nodemon.json ./
-COPY tsconfig.json ./
-COPY tslint.json ./
-COPY seeds ./seeds
-COPY migrations ./migrations
-COPY src ./src
-COPY test ./test
-COPY views ./views
-COPY scripts ./scripts
-COPY public ./public
-COPY scss ./scss
-COPY locales ./locales
+COPY . /app/
 
 CMD ["yarn", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
   web:
-    build: .
+    build:
+      context: .
+      shm_size: 1G
     ports:
       - "8080:8080"
     depends_on:


### PR DESCRIPTION
The `/dev/shm` thing is a trick to make yarn use a _shared memory mount_ as its cache directory. The mount will be purged when the build is finished so it reduces the time it takes for Docker to commit the intermediate image right after yarn dependencies are installed (because writing lots of files to a Docker image takes a lot of time by default). The `--frozen-lockfile` flag ensures that the build will error if the yarn lockfile is not up to date.