### PR TITLE
Add bcrypt hashing on top of existing sha1-based hashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "run-docker": "docker run -p 8080:8080 --env-file=.env -d --name user-service-container user-service"
   },
   "dependencies": {
-    "bcrypt": "^3.0.0",
     "cookie-parser": "^1.4.3",
     "dotenv": "^6.0.0",
     "express": "4.16.3",
@@ -48,12 +47,12 @@
     "node-sass-middleware": "^0.11.0",
     "pug": "^2.0.3",
     "raven": "^2.6.3",
+    "secure-compare": "^3.0.1",
     "sha1": "^1.1.1",
     "typedoc": "^0.11.1",
     "validator": "^10.2.0"
   },
   "devDependencies": {
-    "@types/bcrypt": "^2.0.0",
     "@types/bluebird": "^3.5.22",
     "@types/chai": "^4.1.4",
     "@types/chai-http": "^3.0.5",

--- a/seeds/seedData/users.js
+++ b/seeds/seedData/users.js
@@ -1,5 +1,6 @@
 const sha1 = require("sha1");
-const encryptPassword = (password, salt) => sha1(salt + "kekbUr" + password);
+const bcrypt = require("bcrypt");
+const encryptPassword = (password, salt) => bcrypt.hashSync(sha1(salt + "kekbUr" + password), 13);
 
 module.exports = [
   {
@@ -18,7 +19,7 @@ module.exports = [
     salt: "12345",
     role: "jasen",
     tktl: 1,
-    deleted: 0
+    deleted: 0,
   },
   {
     id: 2,
@@ -36,7 +37,7 @@ module.exports = [
     salt: "12345",
     role: "yllapitaja",
     tktl: 1,
-    deleted: 0
+    deleted: 0,
   },
   {
     id: 3,
@@ -54,7 +55,7 @@ module.exports = [
     salt: "12345",
     role: "jasenvirkailija",
     tktl: 1,
-    deleted: 0
+    deleted: 0,
   },
   {
     id: 4,
@@ -72,6 +73,6 @@ module.exports = [
     salt: "12345",
     role: "tenttiarkistovirkailija",
     tktl: 1,
-    deleted: 0
-  }
+    deleted: 0,
+  },
 ];

--- a/seeds/seedData/users.js
+++ b/seeds/seedData/users.js
@@ -1,6 +1,5 @@
 const sha1 = require("sha1");
-const bcrypt = require("bcrypt");
-const encryptPassword = (password, salt) => bcrypt.hashSync(sha1(salt + "kekbUr" + password), 13);
+const encryptPassword = (password, salt) => sha1(salt + "kekbUr" + password);
 
 module.exports = [
   {

--- a/src/services/AuthenticationService.ts
+++ b/src/services/AuthenticationService.ts
@@ -1,6 +1,5 @@
-import bcrypt from "bcrypt";
-// Ignore sha1 as it has no types
 // @ts-ignore
+import compare from "secure-compare";
 import sha1 from "sha1";
 import ServiceDao from "../dao/ServiceDao";
 import Service, { IServiceDatabaseObject } from "../models/Service";
@@ -147,5 +146,5 @@ export default class AuthenticationService {
  * @returns {Promise<boolean>}
  */
 export async function validatePassword(password: string, salt: string, hashedPassword: string): Promise<boolean> {
-  return await bcrypt.compare(sha1(`${salt}kekbUr${password}`), hashedPassword);
+  return await compare(sha1(`${salt}kekbUr${password}`), hashedPassword);
 }

--- a/src/services/AuthenticationService.ts
+++ b/src/services/AuthenticationService.ts
@@ -30,9 +30,7 @@ export default class AuthenticationService {
    * @memberof AuthenticationService
    */
   public async getService(serviceName: string): Promise<Service> {
-    const service: IServiceDatabaseObject = await this.serviceDao.findByName(
-      serviceName
-    );
+    const service: IServiceDatabaseObject = await this.serviceDao.findByName(serviceName);
     if (!service) {
       throw new ServiceError(404, "Service not found");
     }
@@ -46,12 +44,8 @@ export default class AuthenticationService {
    * @returns {Promise<Service>}
    * @memberof AuthenticationService
    */
-  public async getServiceWithIdentifier(
-    service_identifier: string
-  ): Promise<Service> {
-    const service: IServiceDatabaseObject = await this.serviceDao.findByIdentifier(
-      service_identifier
-    );
+  public async getServiceWithIdentifier(service_identifier: string): Promise<Service> {
+    const service: IServiceDatabaseObject = await this.serviceDao.findByIdentifier(service_identifier);
     if (!service) {
       throw new ServiceError(404, "Service not found");
     }
@@ -67,9 +61,7 @@ export default class AuthenticationService {
   public async getServices(): Promise<Service[]> {
     const services: IServiceDatabaseObject[] = await this.serviceDao.findAll();
 
-    return services.map(
-      (service: IServiceDatabaseObject) => new Service(service)
-    );
+    return services.map((service: IServiceDatabaseObject) => new Service(service));
   }
 
   /**
@@ -80,19 +72,12 @@ export default class AuthenticationService {
    * @returns {string}
    * @memberof AuthenticationService
    */
-  public appendNewServiceAuthenticationToToken(
-    oldToken: string | ServiceToken,
-    newServiceName: string
-  ): string {
+  public appendNewServiceAuthenticationToToken(oldToken: string | ServiceToken, newServiceName: string): string {
     let token: ServiceToken;
     if (typeof oldToken === "string") {
       token = stringToServiceToken(oldToken);
     } else {
-      token = new ServiceToken(
-        oldToken.userId,
-        oldToken.authenticatedTo,
-        oldToken.createdAt
-      );
+      token = new ServiceToken(oldToken.userId, oldToken.authenticatedTo, oldToken.createdAt);
     }
     if (token.authenticatedTo) {
       token.authenticatedTo.push(newServiceName);
@@ -114,19 +99,12 @@ export default class AuthenticationService {
    * @returns {string}
    * @memberof AuthenticationService
    */
-  public removeServiceAuthenticationToToken(
-    oldToken: string | ServiceToken,
-    serviceToRemove: string
-  ): string {
+  public removeServiceAuthenticationToToken(oldToken: string | ServiceToken, serviceToRemove: string): string {
     let token: ServiceToken;
     if (typeof oldToken === "string") {
       token = stringToServiceToken(oldToken);
     } else {
-      token = new ServiceToken(
-        oldToken.userId,
-        oldToken.authenticatedTo,
-        oldToken.createdAt
-      );
+      token = new ServiceToken(oldToken.userId, oldToken.authenticatedTo, oldToken.createdAt);
     }
     const newServiceList: string[] = [];
     token.authenticatedTo.forEach((s: string) => {
@@ -168,14 +146,6 @@ export default class AuthenticationService {
  * @param {string} hashedPassword
  * @returns {Promise<boolean>}
  */
-export async function validatePassword(
-  password: string,
-  salt: string,
-  hashedPassword: string
-): Promise<boolean> {
-  if ((salt === "0" || !salt) && hashedPassword) {
-    return await bcrypt.compare(password, hashedPassword);
-  } else {
-    return sha1(`${salt}kekbUr${password}`) === hashedPassword;
-  }
+export async function validatePassword(password: string, salt: string, hashedPassword: string): Promise<boolean> {
+  return await bcrypt.compare(sha1(`${salt}kekbUr${password}`), hashedPassword);
 }

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,10 +1,9 @@
-import * as bcrypt from "bcrypt";
+import crypto from "crypto";
+import sha1 from "sha1";
 import UserDao from "../dao/UserDao";
 import IUserDatabaseObject, { IUserPaymentDatabaseObject } from "../interfaces/IUserDatabaseObject";
 import User from "../models/User";
 import { UserPayment } from "../models/UserPayment";
-import crypto from "crypto";
-import sha1 from "sha1";
 
 import ServiceError from "../utils/ServiceError";
 import { validatePassword } from "./AuthenticationService";
@@ -217,7 +216,6 @@ async function mkHashedPassword(rawPassword: string): Promise<{ salt: string; pa
   const salt = crypto.randomBytes(16).toString("hex");
   // The passwords are first hashed according to the legacy format
   // to ensure backwards compability
-  const compatPassword = sha1(`${salt}kekbUr${rawPassword}`);
-  const password = await bcrypt.hash(compatPassword, 13);
+  const password = sha1(`${salt}kekbUr${rawPassword}`) as string;
   return { salt, password };
 }

--- a/test/e2e/PrivacyPolicyPage.test.ts
+++ b/test/e2e/PrivacyPolicyPage.test.ts
@@ -16,17 +16,12 @@ import services = require("../../seeds/seedData/services");
 
 import { Server } from "http";
 import app from "../../src/App";
-import UserDao from "../../src/dao/UserDao";
-import User from "../../src/models/User";
-import UserService from "../../src/services/UserService";
 
 // @ts-ignore
 const should: Chai.Should = chai.should();
 
 // Knex instance
 const knex: Knex = Knex(knexfile.test);
-
-const userService: UserService = new UserService(new UserDao(knex));
 
 const serviceData: IServiceDatabaseObject[] = services as IServiceDatabaseObject[];
 
@@ -114,122 +109,6 @@ describe("Privacy policy page", () => {
       "On successful login, privacy policy page is shown for new users (English) - " + service.display_name,
       async () => {
         await browser.get("http://localhost:3010/lang/en/" + service.service_identifier);
-        await browser.findElement(By.id("username")).sendKeys("admin_user");
-        await browser.findElement(By.id("password")).sendKeys("admin_user");
-        await browser.findElement(By.className("accept")).click();
-
-        const containerTitle: string = await browser.findElement(By.id("title")).getText();
-        containerTitle.should.equal(service.display_name + en.privacypolicy_Title);
-
-        const title: string = await browser.getTitle();
-        title.should.equal(service.display_name + en.privacypolicy_Title + " - TKO-äly ry");
-
-        const cancelVal: string = await browser.findElement(By.className("cancel")).getAttribute("value");
-        cancelVal.should.equal(en.privacypolicy_Decline);
-
-        const acceptVal: string = await browser.findElement(By.className("accept")).getAttribute("value");
-        acceptVal.should.equal(en.privacypolicy_Accept);
-
-        const privacyPolicyRedirect: string = await browser
-          .findElement(By.className("privacyPolicyRedirect"))
-          .getText();
-        privacyPolicyRedirect.should.equal(en.privacypolicy_YouWillBeRedirected);
-
-        const privacyPolicyDeclined: string = await browser
-          .findElement(By.className("privacyPolicyDeclineMessage"))
-          .getText();
-        privacyPolicyDeclined.should.equal(
-          en.privacypolicy_IfYouDecline_1 + service.display_name + en.privacypolicy_IfYouDecline_2,
-        );
-      },
-    );
-  }
-
-  for (const service of serviceData) {
-    it(
-      "On successful login, user salt should be rehashed with bcrypt (Finnish) - " + service.display_name,
-      async () => {
-        await browser.get("http://localhost:3010/lang/fi/" + service.service_identifier);
-
-        const userBefore: User = await userService.fetchUser(2);
-        should.exist(userBefore.salt);
-        userBefore.salt.should.not.equal("0");
-
-        await browser.findElement(By.id("username")).sendKeys("admin_user");
-        await browser.findElement(By.id("password")).sendKeys("admin_user");
-        await browser.findElement(By.className("accept")).click();
-
-        const userAfter: User = await userService.fetchUser(2);
-        should.exist(userAfter.salt);
-        userBefore.salt.should.not.equal(userAfter.salt);
-        userAfter.salt.should.equal("0");
-
-        // Relogin to verify that login works with newly hashed password
-        await browser.get("http://localhost:3010/lang/fi/" + service.service_identifier);
-
-        // Recheck salt
-        const userAfter2: User = await userService.fetchUser(2);
-        should.exist(userAfter2.salt);
-        userAfter2.salt.should.equal("0");
-
-        await browser.findElement(By.id("username")).sendKeys("admin_user");
-        await browser.findElement(By.id("password")).sendKeys("admin_user");
-        await browser.findElement(By.className("accept")).click();
-
-        const containerTitle: string = await browser.findElement(By.id("title")).getText();
-        containerTitle.should.equal(service.display_name + " " + fi.privacypolicy_Title);
-
-        const title: string = await browser.getTitle();
-        title.should.equal(service.display_name + " " + fi.privacypolicy_Title + " - TKO-äly ry");
-
-        const cancelVal: string = await browser.findElement(By.className("cancel")).getAttribute("value");
-        cancelVal.should.equal(fi.privacypolicy_Decline);
-
-        const acceptVal: string = await browser.findElement(By.className("accept")).getAttribute("value");
-        acceptVal.should.equal(fi.privacypolicy_Accept);
-
-        const privacyPolicyRedirect: string = await browser
-          .findElement(By.className("privacyPolicyRedirect"))
-          .getText();
-        privacyPolicyRedirect.should.equal(fi.privacypolicy_YouWillBeRedirected);
-
-        const privacyPolicyDeclined: string = await browser
-          .findElement(By.className("privacyPolicyDeclineMessage"))
-          .getText();
-        privacyPolicyDeclined.should.equal(
-          fi.privacypolicy_IfYouDecline_1 + " " + service.display_name + fi.privacypolicy_IfYouDecline_2,
-        );
-      },
-    );
-  }
-
-  for (const service of serviceData) {
-    it(
-      "On successful login, user salt should be rehashed with bcrypt (English) - " + service.display_name,
-      async () => {
-        await browser.get("http://localhost:3010/lang/en/" + service.service_identifier);
-
-        const userBefore: User = await userService.fetchUser(2);
-        should.exist(userBefore.salt);
-        userBefore.salt.should.not.equal("0");
-
-        await browser.findElement(By.id("username")).sendKeys("admin_user");
-        await browser.findElement(By.id("password")).sendKeys("admin_user");
-        await browser.findElement(By.className("accept")).click();
-
-        const userAfter: User = await userService.fetchUser(2);
-        should.exist(userAfter.salt);
-        userBefore.salt.should.not.equal(userAfter.salt);
-        userAfter.salt.should.equal("0");
-
-        // Relogin to verify that login works with newly hashed password
-        await browser.get("http://localhost:3010/lang/en/" + service.service_identifier);
-
-        // Recheck salt
-        const userAfter2: User = await userService.fetchUser(2);
-        should.exist(userAfter2.salt);
-        userAfter2.salt.should.equal("0");
-
         await browser.findElement(By.id("username")).sendKeys("admin_user");
         await browser.findElement(By.id("password")).sendKeys("admin_user");
         await browser.findElement(By.className("accept")).click();

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,11 +104,6 @@
   dependencies:
     "@types/babel-types" "*"
 
-"@types/bcrypt@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/bcrypt/-/bcrypt-2.0.0.tgz#74cccef82026341fd786cf2eb9c912c7f9107c55"
-  integrity sha512-/r/ihQBlYMUYHqcFXix76I3OLYTaUcU8xV2agtB2hCds2rfJI56UyKu0e2LkAW2/4HHmQKmQRFXqM8D6y3Tc5g==
-
 "@types/bluebird@*":
   version "3.5.24"
   resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.24.tgz#11f76812531c14f793b8ecbf1de96f672905de8a"
@@ -679,14 +674,6 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
-
-bcrypt@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-3.0.0.tgz#0cd38983f45143aa5a6122c9660d0b7ec3a33fb0"
-  integrity sha512-gjicxsD4e5U3nH0EqiEb5y+fKpsZ7F52wcnmNfu45nxnolWVAYh7NgbdfilY+5x1v6cLspxmzz4hf+ju2pFxhA==
-  dependencies:
-    nan "2.10.0"
-    node-pre-gyp "0.10.2"
 
 bignumber.js@4.1.0:
   version "4.1.0"
@@ -3373,7 +3360,7 @@ named-placeholders@1.1.1:
   dependencies:
     lru-cache "2.5.0"
 
-nan@2.10.0, nan@^2.10.0, nan@^2.9.2, nan@~2.10.0:
+nan@^2.10.0, nan@^2.9.2, nan@~2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
   integrity sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==
@@ -3395,7 +3382,7 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-needle@^2.2.0, needle@^2.2.1:
+needle@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.2.tgz#1120ca4c41f2fcc6976fd28a8968afe239929418"
   integrity sha512-mW7W8dKuVYefCpNzE3Z7xUmPI9wSrSL/1qH31YGMxmSOAnjatS3S9Zv3cmiHrhx3Jkp1SrWWBdOFXjfF48Uq3A==
@@ -3431,22 +3418,6 @@ node-gyp@^3.8.0:
     semver "~5.3.0"
     tar "^2.0.0"
     which "1"
-
-node-pre-gyp@0.10.2:
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.2.tgz#e8945c20ef6795a20aac2b44f036eb13cf5146e3"
-  integrity sha512-16lql9QTqs6KsB9fl3neWyZm02KxIKdI9FlJjrB0y7eMTP5Nyz+xalwPbOlw3iw7EejllJPmlJSnY711PLD1ug==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.0"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4"
 
 node-pre-gyp@^0.10.0, node-pre-gyp@^0.10.3:
   version "0.10.3"
@@ -4506,6 +4477,11 @@ scss-tokenizer@^0.2.3:
   dependencies:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
+
+secure-compare@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/secure-compare/-/secure-compare-3.0.1.tgz#f1a0329b308b221fae37b9974f3d578d0ca999e3"
+  integrity sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=
 
 selenium-webdriver@^4.0.0-alpha.1:
   version "4.0.0-alpha.1"


### PR DESCRIPTION
This changes the password migration scheme from gradual migration from SHA1 to bcrypt:

* Even though `user-service` converts the old password to `bcrypt`, authenticating software need to be updated to handle both cases as long as there are passwords with the legacy format

* We do not know for sure how long it would take to migrate all accounts as some users might not login for a long time -> leading to potentially having both behaviors in multiple clients for a very long time

* Accounts that are not migrated are unsafe and the security of the gradual migration scheme depends entirely on user activity

* If we choose to simplify clients instead and let them authenticate against the old password, storing both the old and new ones then the gained security is zero

Instead of a gradual migration, this PR changes user-service to assume that the passwords in the database are bcrypt hashes of the _legacy_ SHA1 hashed password, meaning we would need to perform a single migration that simply bcrypts the existing hashed passwords instead of the plaintext password. This would still achieve a better level of security while not requiring access to the user's original plaintext password. Legacy authenticating clients would only have to be updated to wrap their existing SHA1-hashing logic with a bcrypt call instead of supporting dynamic rehashing.

--- 

In order to get this service to production as soon and smoothly as possible, we might want to first remove the bcrypting scheme altogether and just think of switching to user-service as a zero-sum game at this point, and then merge this alongside with the migration later.