### PR TITLE
Cleanup boilerplate jsdoc tags

### DIFF
--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -6,36 +6,10 @@ import UserService from "../services/UserService";
 import AuthorizeMiddleware, { IASRequest } from "../utils/AuthorizeMiddleware";
 import ServiceResponse from "../utils/ServiceResponse";
 
-/**
- * Authentication controller.
- *
- * @export
- * @class AuthController
- * @implements {IController}
- */
 export default class AuthController implements IController {
-  /**
-   * Router
-   *
-   * @private
-   * @type {express.Router}
-   * @memberof AuthController
-   */
   private route: express.Router;
-  /**
-   * Authorization middleware
-   *
-   * @private
-   * @type {AuthorizeMiddleware}
-   * @memberof AuthController
-   */
   private authorizeMiddleware: AuthorizeMiddleware;
 
-  /**
-   * Creates an instance of AuthController.
-   * @param {UserService} userService
-   * @memberof AuthController
-   */
   constructor(
     private userService: UserService,
     private authService: AuthenticationService
@@ -44,14 +18,6 @@ export default class AuthController implements IController {
     this.authorizeMiddleware = new AuthorizeMiddleware(this.userService);
   }
 
-  /**
-   * Used to check authorization to a specified service.
-   *
-   * @param {(express.Request & IASRequest)} req
-   * @param {express.Response} res
-   * @returns {Promise<express.Response>}
-   * @memberof AuthController
-   */
   public async check(
     req: express.Request & IASRequest,
     res: express.Response
@@ -73,14 +39,6 @@ export default class AuthController implements IController {
     }
   }
 
-  /**
-   * Authenticates the user.
-   *
-   * @param {(express.Request & IASRequest)} req
-   * @param {express.Response} res
-   * @returns {Promise<express.Response>}
-   * @memberof AuthController
-   */
   public async authenticateUser(
     req: express.Request & IASRequest,
     res: express.Response
@@ -140,11 +98,6 @@ export default class AuthController implements IController {
 
   /**
    * Renders a view to calculate service permissions.
-   *
-   * @param {(express.Request)} req
-   * @param {express.Response} res
-   * @returns {void}
-   * @memberof AuthController
    */
   public calcPermissions(req: express.Request, res: express.Response): void {
     const dummyObject: User = new User({
@@ -172,11 +125,6 @@ export default class AuthController implements IController {
 
   /**
    * Calculates service permissions.
-   *
-   * @param {(express.Request)} req
-   * @param {express.Response} res
-   * @returns {void}
-   * @memberof AuthController
    */
   public calcPermissionsPost(
     req: express.Request,
@@ -237,9 +185,6 @@ export default class AuthController implements IController {
 
   /**
    * Creates routes for authentication controller.
-   *
-   * @returns
-   * @memberof AuthController
    */
   public createRoutes(): express.Router {
     this.route.get(

--- a/src/controllers/LoginController.ts
+++ b/src/controllers/LoginController.ts
@@ -20,37 +20,12 @@ import AuthorizeMiddleware, {
 import cachingMiddleware from "../utils/CachingMiddleware";
 import ServiceResponse from "../utils/ServiceResponse";
 
-/**
- * Login controller.
- *
- * @export
- * @class LoginController
- * @implements {IController}
- */
 export default class LoginController implements IController {
-  /**
-   * Router.
-   *
-   * @type {Router}
-   * @memberof LoginController
-   */
   public route: Router;
-  /**
-   * Authorization middleware.
-   *
-   * @type {AuthorizeMiddleware}
-   * @memberof LoginController
-   */
   public authorizationMiddleware: AuthorizeMiddleware;
 
   public csrfMiddleware: express.RequestHandler;
 
-  /**
-   * Creates an instance of LoginController.
-   * @param {AuthenticationService} authService
-   * @param {UserService} userService
-   * @memberof LoginController
-   */
   constructor(
     private authService: AuthenticationService,
     private userService: UserService,
@@ -64,14 +39,6 @@ export default class LoginController implements IController {
     });
   }
 
-  /**
-   * Returns the login view.
-   *
-   * @param {(express.Request & IASRequest)} req
-   * @param {express.Response} res
-   * @returns {(Promise<express.Response | void>)}
-   * @memberof LoginController
-   */
   public async getLoginView(
     req: express.Request & IASRequest,
     res: express.Response
@@ -130,11 +97,6 @@ export default class LoginController implements IController {
 
   /**
    * Sets the language of the page.
-   *
-   * @param {(Express.Request & IASRequest)} req
-   * @param {(Express.Response & any)} res
-   * @returns {(Promise<express.Response | void>)}
-   * @memberof LoginController
    */
   public setLanguage(
     req: Express.Request & IASRequest,
@@ -148,14 +110,6 @@ export default class LoginController implements IController {
     return res.redirect(req.params.serviceIdentifier ? "/?serviceIdentifier=" + req.params.serviceIdentifier : "/");
   }
 
-  /**
-   * Logs the user out.
-   *
-   * @param {(express.Request & IASRequest)} req
-   * @param {express.Response} res
-   * @returns
-   * @memberof LoginController
-   */
   public async logOut(
     req: express.Request & IASRequest,
     res: express.Response
@@ -190,7 +144,7 @@ export default class LoginController implements IController {
 
     // this token had one service left which was remove -> clear token
     if (req.authorization.token.authenticatedTo.length === 1) {
-      res.clearCookie("token", {domain: process.env.COOKIE_DOMAIN});
+      res.clearCookie("token", { domain: process.env.COOKIE_DOMAIN });
     } else {
       res.cookie("token", token, {
         maxAge: 1000 * 60 * 60 * 24 * 7,
@@ -204,14 +158,6 @@ export default class LoginController implements IController {
     return res.render("logout", { serviceName: service.displayName });
   }
 
-  /**
-   * Logs the user in.
-   *
-   * @param {(express.Request & IASRequest)} req
-   * @param {express.Response} res
-   * @returns
-   * @memberof LoginController
-   */
   public async login(
     req: express.Request & IASRequest,
     res: express.Response
@@ -360,11 +306,6 @@ export default class LoginController implements IController {
 
   /**
    * Handles GDPR template and redirects the user forward
-   *
-   * @param {(express.Request | IASRequest)} req
-   * @param {express.Response} res
-   * @returns
-   * @memberof LoginController
    */
   public async loginConfirm(
     req: express.Request & IASRequest,
@@ -421,11 +362,6 @@ export default class LoginController implements IController {
 
   /**
    * Handles privacy policy confirmation.
-   *
-   * @param {(express.Request & IASRequest)} req
-   * @param {express.Response} res
-   * @returns {(Promise<express.Response | void>)}
-   * @memberof LoginController
    */
   public async privacyPolicyConfirm(
     req: express.Request & IASRequest,
@@ -486,12 +422,6 @@ export default class LoginController implements IController {
     });
   }
 
-  /**
-   * Create routes for login controller.
-   *
-   * @returns
-   * @memberof LoginController
-   */
   public createRoutes(): express.Router {
     this.route.get(
       "/",
@@ -536,11 +466,6 @@ export default class LoginController implements IController {
   }
 }
 
-/**
- * Session user interface.
- *
- * @interface ISessionUser
- */
 export interface ISessionUser {
   userId: number;
   username: string;

--- a/src/controllers/PaymentController.ts
+++ b/src/controllers/PaymentController.ts
@@ -11,46 +11,11 @@ import ServiceResponse from "../utils/ServiceResponse";
 import { compareRoles } from "../utils/UserHelpers";
 import PaymentValidator from "../validators/PaymentValidator";
 
-/**
- * Payment controller.
- *
- * @export
- * @class PaymentController
- * @implements {IController}
- */
 export default class PaymentController implements IController {
-  /**
-   * Router
-   *
-   * @private
-   * @type {express.Router}
-   * @memberof PaymentController
-   */
   private route: express.Router;
-  /**
-   * Authorize middleware
-   *
-   * @private
-   * @type {AuthorizeMiddleware}
-   * @memberof PaymentController
-   */
   private authorizeMiddleware: AuthorizeMiddleware;
-  /**
-   * Payment validator
-   *
-   * @private
-   * @type {PaymentValidator}
-   * @memberof PaymentController
-   */
   private paymentValidator: PaymentValidator;
 
-  /**
-   * Creates an instance of PaymentController.
-   * @param {UserService} userService
-   * @param {PaymentService} paymentService
-   * @param {AuthenticationService} authenticationService
-   * @memberof PaymentController
-   */
   constructor(
     private userService: UserService,
     private paymentService: PaymentService
@@ -60,14 +25,6 @@ export default class PaymentController implements IController {
     this.authorizeMiddleware = new AuthorizeMiddleware(this.userService);
   }
 
-  /**
-   * Creates a payment.
-   *
-   * @param {express.Request} req
-   * @param {express.Response} res
-   * @returns
-   * @memberof PaymentController
-   */
   public async createPayment(
     req: express.Request,
     res: express.Response
@@ -99,14 +56,6 @@ export default class PaymentController implements IController {
     }
   }
 
-  /**
-   * Modifies a payment.
-   *
-   * @param {express.Request} req
-   * @param {express.Response} res
-   * @returns
-   * @memberof PaymentController
-   */
   public async modifyPayment(
     req: express.Request,
     res: express.Response
@@ -160,14 +109,6 @@ export default class PaymentController implements IController {
     }
   }
 
-  /**
-   * Returns all payments.
-   *
-   * @param {express.Request} req
-   * @param {express.Response} res
-   * @returns
-   * @memberof PaymentController
-   */
   public async getAllPayments(
     req: express.Request & IASRequest,
     res: express.Response
@@ -202,14 +143,6 @@ export default class PaymentController implements IController {
     }
   }
 
-  /**
-   * Returns a single payment.
-   *
-   * @param {express.Request & IASRequest} req
-   * @param {express.Response} res
-   * @returns
-   * @memberof PaymentController
-   */
   public async getSinglePayment(
     req: express.Request & IASRequest,
     res: express.Response
@@ -238,14 +171,6 @@ export default class PaymentController implements IController {
     }
   }
 
-  /**
-   * Marks payments as paid.
-   *
-   * @param {express.Request} req
-   * @param {express.Response} res
-   * @returns
-   * @memberof PaymentController
-   */
   public async markPaymentAsPaid(
     req: express.Request & IASRequest,
     res: express.Response
@@ -278,14 +203,6 @@ export default class PaymentController implements IController {
     }
   }
 
-  /**
-   * Marks payments as paid.
-   *
-   * @param {express.Request} req
-   * @param {express.Response} res
-   * @returns
-   * @memberof PaymentController
-   */
   public async deletePayment(
     req: express.Request & IASRequest,
     res: express.Response
@@ -310,12 +227,6 @@ export default class PaymentController implements IController {
     }
   }
 
-  /**
-   * Creates routes for payment controller.
-   *
-   * @returns
-   * @memberof PaymentController
-   */
   public createRoutes(): express.Router {
     this.route.get(
       "/:id(\\d+)/",

--- a/src/controllers/PrivacyPolicyController.ts
+++ b/src/controllers/PrivacyPolicyController.ts
@@ -4,39 +4,13 @@ import IController from "../interfaces/IController";
 import IPrivacyPolicyDatabaseObject from "../interfaces/IPrivacyPolicyDatabaseObject";
 import ServiceResponse from "../utils/ServiceResponse";
 
-/**
- * Privacy Policy controller.
- *
- * @export
- * @class PrivacyPolicyController
- * @implements {IController}
- */
 export default class PrivacyPolicyController implements IController {
-  /**
-   * Router
-   *
-   * @private
-   * @type {express.Router}
-   * @memberof PaymentController
-   */
   private route: Express.Router;
 
-  /**
-   * Creates an instance of PrivacyPolicyController.
-   * @memberof PrivacyPolicyController
-   */
   constructor(private readonly privacyPolicyDao: PrivacyPolicyDao) {
     this.route = Express.Router();
   }
 
-  /**
-   * Returns a privacy policy.
-   *
-   * @param {Express.Request} req
-   * @param {Express.Response} res
-   * @returns {Promise<Express.Response>}
-   * @memberof PrivacyPolicyController
-   */
   public async GetPrivacyPolicy(
     req: Express.Request,
     res: Express.Response
@@ -61,12 +35,6 @@ export default class PrivacyPolicyController implements IController {
     }
   }
 
-  /**
-   * Creates routes
-   *
-   * @returns {Express.Router}
-   * @memberof PrivacyPolicyController
-   */
   public createRoutes(): Express.Router {
     this.route.get("/:serviceIdentifier", this.GetPrivacyPolicy.bind(this));
 

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -14,42 +14,11 @@ import ServiceResponse from "../utils/ServiceResponse";
 import { compareRoles } from "../utils/UserHelpers";
 import UserValidator from "../validators/UserValidator";
 
-/**
- * User controller.
- *
- * @export
- * @class UserController
- * @implements {IController}
- */
 export default class UserController implements IController {
-  /**
-   * Router
-   *
-   * @type {express.Router}
-   * @memberof UserController
-   */
   public route: express.Router;
-  /**
-   * Authorize middleware
-   *
-   * @type {AuthorizeMiddleware}
-   * @memberof UserController
-   */
   public authorizeMiddleware: AuthorizeMiddleware;
-  /**
-   * User validator
-   *
-   * @type {UserValidator}
-   * @memberof UserController
-   */
   public userValidator: UserValidator;
 
-  /**
-   * Creates an instance of UserController.
-   * @param {UserService} userService
-   * @param {AuthenticationService} authenticationService
-   * @memberof UserController
-   */
   constructor(
     private userService: UserService,
     private authenticationService: AuthenticationService,
@@ -62,11 +31,6 @@ export default class UserController implements IController {
 
   /**
    * Returns the currently logged in user's data.
-   *
-   * @param {(express.Request & IASRequest)} req
-   * @param {express.Response} res
-   * @returns
-   * @memberof UserController
    */
   public async getMe(
     req: express.Request & IASRequest,
@@ -111,14 +75,6 @@ export default class UserController implements IController {
     }
   }
 
-  /**
-   * Returns a single user.
-   *
-   * @param {(express.Request & IASRequest)} req
-   * @param {express.Response} res
-   * @returns
-   * @memberof UserController
-   */
   public async getUser(
     req: express.Request & IASRequest,
     res: express.Response
@@ -175,11 +131,6 @@ export default class UserController implements IController {
 
   /**
    * Returns all users.
-   *
-   * @param {(express.Request & IASRequest)} req
-   * @param {express.Response} res
-   * @returns
-   * @memberof UserController
    */
   public async getAllUsers(
     req: express.Request & IASRequest,
@@ -242,14 +193,6 @@ export default class UserController implements IController {
     }
   }
 
-  /**
-   * Returns all unpaid users.
-   *
-   * @param {express.Request & IASRequest} req
-   * @param {express.Response} res
-   * @returns
-   * @memberof UserController
-   */
   public async getAllUnpaidUsers(
     req: express.Request & IASRequest,
     res: express.Response
@@ -272,14 +215,6 @@ export default class UserController implements IController {
     }
   }
 
-  /**
-   * Modifies a user.
-   *
-   * @param {(express.Request & IASRequest)} req
-   * @param {express.Response} res
-   * @returns
-   * @memberof UserController
-   */
   public async modifyUser(
     req: express.Request & IASRequest,
     res: express.Response
@@ -319,11 +254,6 @@ export default class UserController implements IController {
 
   /**
    * Modifies a user (me).
-   *
-   * @param {(express.Request & IASRequest)} req
-   * @param {express.Response} res
-   * @returns
-   * @memberof UserController
    */
   public async modifyMe(
     req: express.Request & IASRequest,
@@ -356,14 +286,6 @@ export default class UserController implements IController {
     }
   }
 
-  /**
-   * Creates a user.
-   *
-   * @param {express.Request} req
-   * @param {express.Response} res
-   * @returns
-   * @memberof UserController
-   */
   public async createUser(
     req: express.Request,
     res: express.Response
@@ -391,10 +313,6 @@ export default class UserController implements IController {
     }
   }
 
-  /**
-   * Finds payments for user
-   *
-   */
   public async findUserPayment(
     req: express.Request & IASRequest,
     res: express.Response
@@ -431,10 +349,6 @@ export default class UserController implements IController {
     }
   }
 
-  /**
-   * Finds payments for current user
-   *
-   */
   public async findMePayment(
     req: express.Request & IASRequest,
     res: express.Response
@@ -461,14 +375,6 @@ export default class UserController implements IController {
     }
   }
 
-  /**
-   * Sets user membership.
-   *
-   * @param {(express.Request & IASRequest)} req
-   * @param {express.Response} res
-   * @returns {Promise<express.Response>}
-   * @memberof UserController
-   */
   public async setUserMembership(
     req: express.Request & IASRequest,
     res: express.Response
@@ -524,14 +430,6 @@ export default class UserController implements IController {
     }
   }
 
-  /**
-   * Deletes a user.
-   *
-   * @param {(express.Request & IASRequest)} req
-   * @param {express.Response} res
-   * @returns {Promise<express.Response>}
-   * @memberof UserController
-   */
   public async deleteUser(
     req: express.Request & IASRequest,
     res: express.Response
@@ -560,12 +458,6 @@ export default class UserController implements IController {
     }
   }
 
-  /**
-   * Creates routes for UserController.
-   *
-   * @returns
-   * @memberof UserController
-   */
   public createRoutes(): express.Router {
     this.route.get(
       "/:id",

--- a/src/dao/ConsentDao.ts
+++ b/src/dao/ConsentDao.ts
@@ -6,23 +6,9 @@ import IDao from "../interfaces/IDao";
 
 const tableName: string = "privacy_policy_consent_data";
 
-/**
- * Consent Dao.
- *
- * @export
- * @class ConsentDao
- * @implements {IDao<IConsentDatabaseObject>}
- */
 export default class ConsentDao implements IDao<IConsentDatabaseObject> {
   constructor(private readonly knex: Knex) { }
 
-  /**
-   * Finds a single consent.
-   *
-   * @param {number} id Consent ID
-   * @returns {Promise<IConsentDatabaseObject>} A single consent
-   * @memberof ConsentDao
-   */
   public findOne(id: number): Promise<IConsentDatabaseObject> {
     return Promise.resolve(
       this.knex(tableName)
@@ -30,22 +16,11 @@ export default class ConsentDao implements IDao<IConsentDatabaseObject> {
         .first()
     );
   }
-  /**
-   * Finds all consents.
-   *
-   * @returns {Promise<IConsentDatabaseObject[]>} All consents
-   * @memberof ConsentDao
-   */
+
   public findAll(): Promise<IConsentDatabaseObject[]> {
     return Promise.resolve(this.knex(tableName).select());
   }
-  /**
-   * Removes a consent.
-   *
-   * @param {number} id Consent id
-   * @returns {Promise<boolean>}
-   * @memberof ConsentDao
-   */
+
   public remove(id: number): Promise<boolean> {
     return Promise.resolve(
       this.knex(tableName)
@@ -53,14 +28,7 @@ export default class ConsentDao implements IDao<IConsentDatabaseObject> {
         .where({ id })
     );
   }
-  /**
-   * Updates a consent.
-   *
-   * @param {number} entityId Consent ID
-   * @param {IConsentDatabaseObject} entity Consent
-   * @returns {Promise<number>}
-   * @memberof ConsentDao
-   */
+
   public update(
     entityId: number,
     entity: IConsentDatabaseObject
@@ -73,11 +41,9 @@ export default class ConsentDao implements IDao<IConsentDatabaseObject> {
         .where({ id: entityId })
     );
   }
+
   /**
    * Resets privacy policy consent for all users that have accepted it, for a single service.
-   *
-   * @returns {Promise<number[]>}
-   * @memberof ConsentDao
    */
   public resetAllAcceptedByService(service_id: number): Promise<number[]> {
     return Promise.resolve(
@@ -87,13 +53,6 @@ export default class ConsentDao implements IDao<IConsentDatabaseObject> {
     );
   }
 
-  /**
-   * Finds all consents by service.
-   *
-   * @param {number} service_id Service id
-   * @returns {Promise<IConsentDatabaseObject[]>} Consents by service
-   * @memberof ConsentDao
-   */
   public findAllByServiceId(
     service_id: number
   ): Promise<IConsentDatabaseObject[]> {
@@ -104,13 +63,6 @@ export default class ConsentDao implements IDao<IConsentDatabaseObject> {
     );
   }
 
-  /**
-   * Finds all consents by user.
-   *
-   * @param {number} service_id Service id
-   * @returns {Promise<IConsentDatabaseObject[]>} Consents by service
-   * @memberof ConsentDao
-   */
   public findAllByUserId(user_id: number): Promise<IConsentDatabaseObject[]> {
     return Promise.resolve(
       this.knex(tableName)
@@ -119,14 +71,6 @@ export default class ConsentDao implements IDao<IConsentDatabaseObject> {
     );
   }
 
-  /**
-   * Finds a consent by a user and a service.
-   *
-   * @param {number} user_id User ID
-   * @param {number} service_id Service ID
-   * @returns {Promise<IConsentDatabaseObject>}
-   * @memberof ConsentDao
-   */
   public findByUserAndService(
     user_id: number,
     service_id: number
@@ -139,12 +83,6 @@ export default class ConsentDao implements IDao<IConsentDatabaseObject> {
     );
   }
 
-  /**
-   * Finds all declined consents.
-   *
-   * @returns {Promise<IConsentDatabaseObject[]>} Declined consents
-   * @memberof ConsentDao
-   */
   public findAllDeclined(): Promise<IConsentDatabaseObject[]> {
     return Promise.resolve(
       this.knex(tableName)
@@ -153,13 +91,6 @@ export default class ConsentDao implements IDao<IConsentDatabaseObject> {
     );
   }
 
-  /**
-   * Saves a new consent.
-   *
-   * @param {IConsentDatabaseObject} entity Consent
-   * @returns {Promise<number[]>}
-   * @memberof ConsentDao
-   */
   public save(entity: IConsentDatabaseObject): Promise<number[]> {
     entity.created = new Date();
     entity.modified = new Date();

--- a/src/dao/PaymentDao.ts
+++ b/src/dao/PaymentDao.ts
@@ -3,28 +3,9 @@ import * as Knex from "knex";
 import IDao from "../interfaces/IDao";
 import { IPayment, IPaymentListing } from "../models/Payment";
 
-/**
- * Payment dao.
- *
- * @export
- * @class PaymentDao
- * @implements {Dao<IPayment>}
- */
 export default class PaymentDao implements IDao<IPayment> {
-  /**
-   * Creates an instance of PaymentDao.
-   * @param {Knex} knex
-   * @memberof PaymentDao
-   */
   constructor(private readonly knex: Knex) { }
 
-  /**
-   * Finds a single payment.
-   *
-   * @param {number} id Payment id
-   * @returns {Promise<IPayment>}
-   * @memberof PaymentDao
-   */
   public findOne(id: number): Promise<IPayment> {
     return Promise.resolve(
       this.knex("payments")
@@ -34,14 +15,6 @@ export default class PaymentDao implements IDao<IPayment> {
     );
   }
 
-  /**
-   * Finds a payment by payer.
-   *
-   * @param {number} payer_id
-   * @param {boolean} [validPayment] If set to true, only searches for valid payments
-   * @returns {Promise<IPayment>}
-   * @memberof PaymentDao
-   */
   public findByPayer(
     payer_id: number,
     validPayment?: boolean
@@ -57,13 +30,6 @@ export default class PaymentDao implements IDao<IPayment> {
     return Promise.resolve(query.first());
   }
 
-  /**
-   * Finds a payment by confirmer.
-   *
-   * @param {number} confirmer_id
-   * @returns {Promise<IPayment>} Payment by confirmer.
-   * @memberof PaymentDao
-   */
   public findByConfirmer(confirmer_id: number): Promise<IPayment> {
     return Promise.resolve(
       this.knex("payments")
@@ -73,23 +39,10 @@ export default class PaymentDao implements IDao<IPayment> {
     );
   }
 
-  /**
-   * Finds all payments.
-   *
-   * @returns {Promise<IPayment[]>}
-   * @memberof PaymentDao
-   */
   public findAll(): Promise<IPayment[]> {
     return Promise.resolve(this.knex("payments").select());
   }
 
-  /**
-   * Removes a payment.
-   *
-   * @param {number} id Payment id
-   * @returns {Promise<boolean>}
-   * @memberof PaymentDao
-   */
   public remove(id: number): Promise<boolean> {
     return Promise.resolve(
       this.knex("payments")
@@ -98,14 +51,6 @@ export default class PaymentDao implements IDao<IPayment> {
     );
   }
 
-  /**
-   * Updates a payment.
-   *
-   * @param {number} entityId Entity ID
-   * @param {IPayment} entity Payment
-   * @returns {Promise<number>} Affected rows.
-   * @memberof PaymentDao
-   */
   public update(entityId: number, entity: IPayment): Promise<number> {
     return Promise.resolve(
       this.knex("payments")
@@ -114,13 +59,6 @@ export default class PaymentDao implements IDao<IPayment> {
     );
   }
 
-  /**
-   * Saves a payment.
-   *
-   * @param {IPayment} entity Payment
-   * @returns {Promise<number[]>} Inserted payment ID.
-   * @memberof PaymentDao
-   */
   public save(entity: IPayment): Promise<number[]> {
     // Delete id because it's auto-assigned
     if (entity.id) {
@@ -129,14 +67,6 @@ export default class PaymentDao implements IDao<IPayment> {
     return Promise.resolve(this.knex("payments").insert(entity));
   }
 
-  /**
-   * Finds payments by payment type.
-   *
-   * @private
-   * @param {string} payment_type Payment type
-   * @returns {Promise<IPayment[]>} List of payments
-   * @memberof PaymentDao
-   */
   public findPaymentsByPaymentType(
     payment_type: string
   ): Promise<IPaymentListing[]> {
@@ -155,12 +85,6 @@ export default class PaymentDao implements IDao<IPayment> {
     );
   }
 
-  /**
-   * Finds unpaid payments
-   *
-   * @returns {Promise<IPayment[]>} List of payments
-   * @memberof PaymentDao
-   */
   public findUnpaid(): Promise<IPaymentListing[]> {
     const query: Knex.QueryBuilder = this.knex("payments")
       .select("payments.*", "users.name as payer_name")
@@ -170,14 +94,6 @@ export default class PaymentDao implements IDao<IPayment> {
     return Promise.resolve(query);
   }
 
-  /**
-   * Confirms a payment.
-   *
-   * @param {number} payment_id Payment ID
-   * @param {number} confirmer_id Confirmer ID
-   * @returns {Promise<boolean>} True if the update was successful.
-   * @memberof PaymentDao
-   */
   public confirmPayment(
     payment_id: number,
     confirmer_id: number
@@ -194,12 +110,6 @@ export default class PaymentDao implements IDao<IPayment> {
 
   /**
    * Marks a payment paid by cash.
-   *
-   * @param {number} payment_id Payment ID
-   * @param {number} confirmer_id Confirmer ID
-   * @param {string} payment_type Payment type
-   * @returns {Promise<boolean>} True if the update was successful.
-   * @memberof PaymentDao
    */
   public makePaid(
     payment_id: number,
@@ -217,12 +127,6 @@ export default class PaymentDao implements IDao<IPayment> {
     );
   }
 
-  /**
-   * Delete payment
-   *
-   * @param {number} id Payment id
-   * @memberof PaymentDao
-   */
   public deletePayment(id: number): Promise<boolean> {
     return Promise.resolve(
       this.knex("payments")

--- a/src/dao/PrivacyPolicyDao.ts
+++ b/src/dao/PrivacyPolicyDao.ts
@@ -3,29 +3,11 @@ import * as Knex from "knex";
 import IDao from "../interfaces/IDao";
 import IPrivacyPolicyDatabaseObject from "../interfaces/IPrivacyPolicyDatabaseObject";
 
-/**
- * Privacy policy Dao.
- *
- * @export
- * @class PrivacyPolicyDao
- * @implements {IDao<IPrivacyPolicyDatabaseObject>}
- */
 export default class PrivacyPolicyDao
   implements IDao<IPrivacyPolicyDatabaseObject> {
-  /**
-   * Creates an instance of PrivacyPolicyDao.
-   * @param {Knex} knex
-   * @memberof PrivacyPolicyDao
-   */
+
   constructor(private readonly knex: Knex) { }
 
-  /**
-   * Finds one privacy policy.
-   *
-   * @param {number} id
-   * @returns {Promise<IPrivacyPolicyDatabaseObject>} Privacy policy
-   * @memberof PrivacyPolicyDao
-   */
   public findOne(id: number): Promise<IPrivacyPolicyDatabaseObject> {
     return Promise.resolve(this.knex
       .select()
@@ -36,10 +18,6 @@ export default class PrivacyPolicyDao
 
   /**
    * Finds privacy policy for a service, by the service's identifier.
-   *
-   * @param {string} serviceIdentifier Service identifier
-   * @returns {Promise<IPrivacyPolicyDatabaseObject>}
-   * @memberof PrivacyPolicyDao
    */
   public findByServiceIdentifier(
     serviceIdentifier: string
@@ -58,13 +36,6 @@ export default class PrivacyPolicyDao
       .first());
   }
 
-  /**
-   * Finds a privacy policy by name.
-   *
-   * @param {string} name Privacy policy name
-   * @returns {Promise<IPrivacyPolicyDatabaseObject>} Privacy policy
-   * @memberof PrivacyPolicyDao
-   */
   public findByName(name: string): Promise<IPrivacyPolicyDatabaseObject> {
     return Promise.resolve(this.knex
       .select()
@@ -73,23 +44,10 @@ export default class PrivacyPolicyDao
       .first());
   }
 
-  /**
-   * Finds all privacy policies.
-   *
-   * @returns {Promise<IPrivacyPolicyDatabaseObject[]>} Privacy policies
-   * @memberof PrivacyPolicyDao
-   */
   public findAll(): Promise<IPrivacyPolicyDatabaseObject[]> {
     return Promise.resolve(this.knex.select().from("privacy_policies"));
   }
 
-  /**
-   * Removes a privacy policy.
-   *
-   * @param {number} id Privacy policy id
-   * @returns {Promise<boolean>}
-   * @memberof PrivacyPolicyDao
-   */
   public remove(id: number): Promise<boolean> {
     return Promise.resolve(this.knex
       .delete()
@@ -97,14 +55,6 @@ export default class PrivacyPolicyDao
       .where({ id }));
   }
 
-  /**
-   * Updates a privacy policy.
-   *
-   * @param {number} entityId Privacy policy id
-   * @param {IPrivacyPolicyDatabaseObject} entity Privacy policy
-   * @returns {Promise<number>}
-   * @memberof PrivacyPolicyDao
-   */
   public update(
     entityId: number,
     entity: IPrivacyPolicyDatabaseObject
@@ -118,13 +68,6 @@ export default class PrivacyPolicyDao
       .where({ id: entityId }));
   }
 
-  /**
-   * Saves a privacy policy.
-   *
-   * @param {IPrivacyPolicyDatabaseObject} entity Privacy policy
-   * @returns {Promise<number[]>}
-   * @memberof PrivacyPolicyDao
-   */
   public save(entity: IPrivacyPolicyDatabaseObject): Promise<number[]> {
     if (entity.id) {
       delete entity.id;

--- a/src/dao/ServiceDao.ts
+++ b/src/dao/ServiceDao.ts
@@ -3,28 +3,9 @@ import * as Knex from "knex";
 import IDao from "../interfaces/IDao";
 import { IServiceDatabaseObject } from "../models/Service";
 
-/**
- * Service dao.
- *
- * @export
- * @class ServiceDao
- * @implements {Dao<IServiceDatabaseObject>}
- */
 export default class ServiceDao implements IDao<IServiceDatabaseObject> {
-  /**
-   * Creates an instance of ServiceDao.
-   * @param {Knex} knex
-   * @memberof ServiceDao
-   */
   constructor(private readonly knex: Knex) { }
 
-  /**
-   * Finds a single service.
-   *
-   * @param {number} id Service id
-   * @returns {Promise<IServiceDatabaseObject>}
-   * @memberof ServiceDao
-   */
   public findOne(id: number): Promise<IServiceDatabaseObject> {
     return Promise.resolve(
       this.knex("services")
@@ -34,13 +15,6 @@ export default class ServiceDao implements IDao<IServiceDatabaseObject> {
     );
   }
 
-  /**
-   * Finds a service by its identifier.
-   *
-   * @param {string} service_identifier Service identifier
-   * @returns {Promise<IServiceDatabaseObject>}
-   * @memberof ServiceDao
-   */
   public findByIdentifier(
     service_identifier: string
   ): Promise<IServiceDatabaseObject> {
@@ -52,13 +26,6 @@ export default class ServiceDao implements IDao<IServiceDatabaseObject> {
     );
   }
 
-  /**
-   * Finds a service by its name.
-   *
-   * @param {string} service_name Service name
-   * @returns {Promise<IServiceDatabaseObject>}
-   * @memberof ServiceDao
-   */
   public findByName(service_name: string): Promise<IServiceDatabaseObject> {
     return Promise.resolve(
       this.knex("services")
@@ -68,23 +35,10 @@ export default class ServiceDao implements IDao<IServiceDatabaseObject> {
     );
   }
 
-  /**
-   * Finds all services.
-   *
-   * @returns {Promise<IServiceDatabaseObject[]>}
-   * @memberof ServiceDao
-   */
   public findAll(): Promise<IServiceDatabaseObject[]> {
     return Promise.resolve(this.knex("services").select());
   }
 
-  /**
-   * Removes a single service.
-   *
-   * @param {number} id Service id
-   * @returns {Promise<boolean>}
-   * @memberof ServiceDao
-   */
   public remove(id: number): Promise<boolean> {
     return Promise.resolve(
       this.knex("privacy_policy_consent_data")
@@ -103,13 +57,6 @@ export default class ServiceDao implements IDao<IServiceDatabaseObject> {
     );
   }
 
-  /**
-   * Updates a single service.
-   *
-   * @param {IServiceDatabaseObject} entity Service
-   * @returns {Promise<number[]>} Affected rows
-   * @memberof ServiceDao
-   */
   public update(
     entityId: number,
     entity: IServiceDatabaseObject
@@ -126,13 +73,6 @@ export default class ServiceDao implements IDao<IServiceDatabaseObject> {
     );
   }
 
-  /**
-   * Saves a new service.
-   *
-   * @param {IServiceDatabaseObject} entity Service
-   * @returns {Promise<number[]>} Inserted ID(s)
-   * @memberof ServiceDao
-   */
   public save(entity: IServiceDatabaseObject): Promise<number[]> {
     // Delete id because it's auto-assigned
     if (entity.id) {

--- a/src/dao/UserDao.ts
+++ b/src/dao/UserDao.ts
@@ -5,28 +5,9 @@ import IUserDatabaseObject, {
   IUserPaymentDatabaseObject
 } from "../interfaces/IUserDatabaseObject";
 
-/**
- * User dao.
- *
- * @export
- * @class UserDao
- * @implements {Dao<User>}
- */
 export default class UserDao implements IDao<IUserDatabaseObject> {
-  /**
-   * Creates an instance of UserDao.
-   * @param {Knex} knex
-   * @memberof UserDao
-   */
   constructor(private readonly knex: Knex) { }
 
-  /**
-   * Finds a single user.
-   *
-   * @param {number} id User id
-   * @returns {Promise<IUserDatabaseObject>}
-   * @memberof UserDao
-   */
   public findOne(id: number): Promise<IUserDatabaseObject> {
     return Promise.resolve(
       this.knex("users")
@@ -36,13 +17,6 @@ export default class UserDao implements IDao<IUserDatabaseObject> {
     );
   }
 
-  /**
-   * Finds a single user by its username.
-   *
-   * @param {string} username Username
-   * @returns {Promise<IUserDatabaseObject>} User
-   * @memberof UserDao
-   */
   public findByUsername(username: string): Promise<IUserDatabaseObject> {
     return Promise.resolve(
       this.knex("users")
@@ -52,13 +26,6 @@ export default class UserDao implements IDao<IUserDatabaseObject> {
     );
   }
 
-  /**
-   * Finds a single user by its email address.
-   *
-   * @param {string} email Email address
-   * @returns {Promise<IUserDatabaseObject>} User
-   * @memberof UserDao
-   */
   public findByEmail(email: string): Promise<IUserDatabaseObject> {
     return Promise.resolve(
       this.knex("users")
@@ -70,10 +37,6 @@ export default class UserDao implements IDao<IUserDatabaseObject> {
 
   /**
    * Finds a single user who hasn't paid his/her bill.
-   *
-   * @param {number} id User id
-   * @returns {Promise<IUserDatabaseObject>} User
-   * @memberof UserDao
    */
   public findByUnpaidPayment(id: number): Promise<IUserDatabaseObject> {
     return Promise.resolve(
@@ -88,9 +51,6 @@ export default class UserDao implements IDao<IUserDatabaseObject> {
 
   /**
    * Finds all users who haven't paid their bill.
-   *
-   * @returns {Promise<IUserDatabaseObject[]>} List of users
-   * @memberof UserDao
    */
   public findAllByUnpaidPayment(): Promise<IUserDatabaseObject[]> {
     return Promise.resolve(
@@ -101,12 +61,6 @@ export default class UserDao implements IDao<IUserDatabaseObject> {
     );
   }
 
-  /**
-   * Finds all users.
-   *
-   * @returns {Promise<IUserDatabaseObject[]>}
-   * @memberof UserDao
-   */
   public findAll(
     fields?: string[],
     conditions?: string[]
@@ -137,10 +91,6 @@ export default class UserDao implements IDao<IUserDatabaseObject> {
 
   /**
    * Search the user table with the specified search term.
-   *
-   * @param {string} searchTerm Search term
-   * @returns {Promise<IUserDatabaseObject[]>}
-   * @memberof UserDao
    */
   public findWhere(searchTerm: string): Promise<IUserDatabaseObject[]> {
     return Promise.resolve(
@@ -158,10 +108,6 @@ export default class UserDao implements IDao<IUserDatabaseObject> {
    * Removes a single user.
    *
    * Note: You need to remove payments of the user first.
-   *
-   * @param {number} id User id
-   * @returns {Promise<boolean>}
-   * @memberof UserDao
    */
   public remove(id: number): PromiseLike<boolean> {
     // First, delete consents
@@ -175,14 +121,6 @@ export default class UserDao implements IDao<IUserDatabaseObject> {
       });
   }
 
-  /**
-   * Updates a single user.
-   *
-   * @param {number} entityId User id
-   * @param {IUserDatabaseObject} entity Entity
-   * @returns {Promise<number[]>} Affected rows
-   * @memberof UserDao
-   */
   public update(
     entityId: number,
     entity: IUserDatabaseObject
@@ -198,13 +136,6 @@ export default class UserDao implements IDao<IUserDatabaseObject> {
     );
   }
 
-  /**
-   * Saves a single user.
-   *
-   * @param {IUserDatabaseObject} entity
-   * @returns {Promise<number[]>} Inserted ID(s)
-   * @memberof UserDao
-   */
   public save(entity: IUserDatabaseObject): Promise<number[]> {
     // Delete id because it's auto-assigned
     if (entity.id) {

--- a/src/enum/UserRoleString.ts
+++ b/src/enum/UserRoleString.ts
@@ -1,9 +1,3 @@
-/**
- * User role enumerator.
- *
- * @export
- * @enum {number}
- */
 enum UserRoleString {
   Kayttaja = "kayttaja",
   Virkailija = "virkailija",

--- a/src/interfaces/IConsentDatabaseObject.ts
+++ b/src/interfaces/IConsentDatabaseObject.ts
@@ -1,11 +1,5 @@
 import PrivacyPolicyConsent from "../enum/PrivacyPolicyConsent";
 
-/**
- * Privacy policy interface.
- *
- * @export
- * @interface IConsentDatabaseObject
- */
 export default interface IConsentDatabaseObject {
   id?: number;
   user_id?: number;

--- a/src/interfaces/IController.ts
+++ b/src/interfaces/IController.ts
@@ -1,17 +1,5 @@
 import * as express from "express";
 
-/**
- * IController interface.
- *
- * @export
- * @interface IController
- */
 export default interface IController {
-  /**
-   * Creates routes for the controller.
-   *
-   * @returns {express.Router}
-   * @memberof IController
-   */
   createRoutes(): express.Router;
 }

--- a/src/interfaces/IDao.ts
+++ b/src/interfaces/IDao.ts
@@ -1,48 +1,22 @@
-/**
- * Dao interface.
- *
- * @export
- * @interface IDao
- * @template T
- */
 export default interface IDao<T> {
   /**
    * Returns an entity by its id.
-   *
-   * @param {number} id Entity id
-   * @returns {Promise<T>} A single entity
-   * @memberof IDao
    */
   findOne(id: number): PromiseLike<T>;
   /**
    * Returns all entities.
-   *
-   * @returns {Promise<T[]>} All entities
-   * @memberof IDao
    */
   findAll(): PromiseLike<T[]>;
   /**
    * Removes an entity.
-   *
-   * @param {number} id Entity id
-   * @returns {Promise<boolean>} Did the remove complete or not
-   * @memberof IDao
    */
   remove(id: number): PromiseLike<boolean>;
   /**
    * Updates an entity.
-   *
-   * @param {T} entity Entity
-   * @returns {Promise<number[]>} Affected row(s)
-   * @memberof IDao
    */
   update(entityId: number, entity: T): PromiseLike<number>;
   /**
    * Saves an entity.
-   *
-   * @param {T} entity
-   * @returns {Promise<number[]>} Inserted id(s)
-   * @memberof IDao
    */
   save(entity: T): PromiseLike<number[]>;
 }

--- a/src/interfaces/IParsedTokenContents.ts
+++ b/src/interfaces/IParsedTokenContents.ts
@@ -1,8 +1,3 @@
-/**
- * Interface for parsed token contents.
- *
- * @interface ParsedTokenContents
- */
 export default interface IParsedTokenContents {
   userId: number;
   authenticatedTo: string;

--- a/src/interfaces/IPrivacyPolicyDatabaseObject.ts
+++ b/src/interfaces/IPrivacyPolicyDatabaseObject.ts
@@ -1,9 +1,3 @@
-/**
- * Privacy policy interface.
- *
- * @export
- * @interface IPrivacyPolicy
- */
 export default interface IPrivacyPolicyDatabaseObject {
   id?: number;
   service_id?: number;

--- a/src/interfaces/IService.ts
+++ b/src/interfaces/IService.ts
@@ -1,9 +1,5 @@
 /**
  * Service interface. All services must implement this interface.
- *
- * @export
- * @interface IService
- * @template T
  */
 export default interface IService<T> {
   findOne(id: number): Promise<T>;

--- a/src/interfaces/IUserDatabaseObject.ts
+++ b/src/interfaces/IUserDatabaseObject.ts
@@ -1,8 +1,3 @@
-/**
- * User database object.
- *
- * @interface IUserDatabaseObject
- */
 export default interface IUserDatabaseObject {
   id?: number;
   username?: string;
@@ -24,8 +19,6 @@ export default interface IUserDatabaseObject {
 
 /**
  * User database object with additional payment information
- *
- * @interface IUserPaymentDatabaseObject
  */
 export interface IUserPaymentDatabaseObject extends IUserDatabaseObject {
   paid?: Date;

--- a/src/interfaces/IValidator.ts
+++ b/src/interfaces/IValidator.ts
@@ -1,26 +1,14 @@
 import User from "../models/User";
 
-/**
- * IValidator interface.
- *
- * @export
- * @interface IValidator
- * @template T
- */
 export default interface IValidator<T> {
   /**
    * Validates entity creation.
-   *
-   * @param {T} bodyData Entity
-   * @memberof IValidator
+   * TODO: Document how the actual validation occurs here
    */
   validateCreate(bodyData: T): void;
   /**
    * Validates entity update.
-   *
-   * @param {number} dataId
-   * @param {T} newData New data
-   * @memberof IValidator
+   * TODO: Document how the actual validation occurs here
    */
   validateUpdate(dataId: number, newData: T, validator: User): void;
 }

--- a/src/models/Consent.ts
+++ b/src/models/Consent.ts
@@ -1,62 +1,14 @@
 import PrivacyPolicyConsent from "../enum/PrivacyPolicyConsent";
 import IConsentDatabaseObject from "../interfaces/IConsentDatabaseObject";
 
-/**
- * Consent model.
- *
- * @export
- * @class Consent
- * @implements {IConsentDatabaseObject}
- */
 export default class Consent implements IConsentDatabaseObject {
-  /**
-   * ID
-   *
-   * @type {number}
-   * @memberof Consent
-   */
   public id: number;
-  /**
-   * User ID
-   *
-   * @type {number}
-   * @memberof Consent
-   */
   public user_id: number;
-  /**
-   * Service ID
-   *
-   * @type {number}
-   * @memberof Consent
-   */
   public service_id: number;
-  /**
-   * Consent status
-   *
-   * @type {PrivacyPolicyConsent}
-   * @memberof Consent
-   */
   public consent: PrivacyPolicyConsent;
-  /**
-   * Modified date
-   *
-   * @type {Date}
-   * @memberof Consent
-   */
   public modified: Date;
-  /**
-   * Created date
-   *
-   * @type {Date}
-   * @memberof Consent
-   */
   public created: Date;
 
-  /**
-   * Creates an instance of Consent.
-   * @param {IConsentDatabaseObject} consent
-   * @memberof Consent
-   */
   constructor(consent: IConsentDatabaseObject) {
     Object.keys(consent).forEach((key: keyof IConsentDatabaseObject) => {
       this[key] = consent[key];

--- a/src/models/Payment.ts
+++ b/src/models/Payment.ts
@@ -1,9 +1,3 @@
-/**
- * IPayment interface.
- *
- * @export
- * @interface IPayment
- */
 export interface IPayment {
   id?: number;
   payer_id?: number;
@@ -16,94 +10,23 @@ export interface IPayment {
   payment_type?: string;
 }
 
-/**
- * Payment class.
- *
- * @export
- * @class Payment
- * @implements {IPayment}
- */
 export default class Payment implements IPayment {
-  /**
-   * ID
-   *
-   * @type {number}
-   * @memberof Payment
-   */
   public id: number;
-  /**
-   * Payer ID
-   *
-   * @type {number}
-   * @memberof Payment
-   */
   public payer_id: number;
-  /**
-   * Confirmer ID
-   *
-   * @type {number}
-   * @memberof Payment
-   */
   public confirmer_id: number;
-  /**
-   * Creation date
-   *
-   * @type {Date}
-   * @memberof Payment
-   */
   public created: Date;
-  /**
-   * Reference number
-   *
-   * @type {string}
-   * @memberof Payment
-   */
   public reference_number: string;
-  /**
-   * Amount
-   *
-   * @type {number}
-   * @memberof Payment
-   */
   public amount: number;
-  /**
-   * Valid until -date
-   *
-   * @type {Date}
-   * @memberof Payment
-   */
   public valid_until: Date;
-  /**
-   * Paid date
-   *
-   * @type {Date}
-   * @memberof Payment
-   */
   public paid: Date;
-  /**
-   * Payment type
-   *
-   * @type {string}
-   * @memberof Payment
-   */
   public payment_type: string;
 
-  /**
-   * Creates an instance of Payment.
-   * @param {IPayment} payment
-   * @memberof Payment
-   */
   constructor(payment: IPayment) {
     Object.keys(payment).forEach((key: keyof IPayment) => {
       this[key] = payment[key];
     });
   }
 
-  /**
-   * Generates a reference number.
-   *
-   * @memberof Payment
-   */
   public generateReferenceNumber(): void {
     const baseNumber: string = "10" + String(this.id);
     if (baseNumber.length < 3 || baseNumber.length > 19) {

--- a/src/models/PaymentListing.ts
+++ b/src/models/PaymentListing.ts
@@ -1,26 +1,9 @@
 import Payment, { IPaymentListing } from "./Payment";
-/**
- * Payment listing.
- *
- * @export
- * @class PaymentListing
- * @extends {Payment}
- */
+
 export class PaymentListing extends Payment {
-  /**
-   * Payer name
-   *
-   * @type {string}
-   * @memberof PaymentListing
-   */
   public payerName: string;
-  /**
-   * Confirmer name
-   *
-   * @type {string}
-   * @memberof PaymentListing
-   */
   public confirmerName: string;
+
   constructor(dbEntity: IPaymentListing) {
     super(dbEntity);
     this.payerName = dbEntity.payer_name;

--- a/src/models/PrivacyPolicy.ts
+++ b/src/models/PrivacyPolicy.ts
@@ -1,47 +1,10 @@
 import IPrivacyPolicyDatabaseObject from "../interfaces/IPrivacyPolicyDatabaseObject";
 
-/**
- * Privacy policy model.
- *
- * @export
- * @class PrivacyPolicy
- * @implements {IPrivacyPolicyDatabaseObject}
- */
 export default class PrivacyPolicy implements IPrivacyPolicyDatabaseObject {
-  /**
-   * ID
-   *
-   * @type {number}
-   * @memberof PrivacyPolicy
-   */
   public id?: number;
-  /**
-   * Name
-   *
-   * @type {number}
-   * @memberof PrivacyPolicy
-   */
   public service_id?: number;
-  /**
-   * Service
-   *
-   * @type {string}
-   * @memberof PrivacyPolicy
-   */
   public text?: string;
-  /**
-   * Modified
-   *
-   * @type {Date}
-   * @memberof PrivacyPolicy
-   */
   public modified?: Date;
-  /**
-   * Created
-   *
-   * @type {Date}
-   * @memberof PrivacyPolicy
-   */
   public created?: Date;
 
   constructor(privacyPolicy: IPrivacyPolicyDatabaseObject) {

--- a/src/models/Service.ts
+++ b/src/models/Service.ts
@@ -1,74 +1,15 @@
-/**
- * Service object.
- *
- * @export
- * @class Service
- */
 export default class Service {
-  /**
-   * Service id.
-   *
-   * @type {number}
-   * @memberof Service
-   */
   public id: number;
-  /**
-   * Service name.
-   *
-   * @type {string}
-   * @memberof Service
-   */
   public serviceName: string;
-  /**
-   * Service identifier.
-   *
-   * @type {string}
-   * @memberof Service
-   */
   public serviceIdentifier: string;
-  /**
-   * Display name.
-   *
-   * @type {string}
-   * @memberof Service
-   */
   public displayName: string;
-  /**
-   * Redirect url.
-   *
-   * @type {string}
-   * @memberof Service
-   */
   public redirectUrl: string;
-  /**
-   * Data permissions.
-   *
-   * @type {number}
-   * @memberof Service
-   */
   public dataPermissions: number;
 
-  /**
-   * Created at date.
-   *
-   * @type {Date}
-   * @memberof Service
-   */
   public createdAt: Date;
 
-  /**
-   * Modified at date.
-   *
-   * @type {Date}
-   * @memberof Service
-   */
   public modifiedAt: Date;
 
-  /**
-   * Creates an instance of Service.
-   * @param {ServiceDatabaseObject} databaseObject
-   * @memberof Service
-   */
   constructor(databaseObject: IServiceDatabaseObject) {
     this.id = databaseObject.id;
     this.serviceName = databaseObject.service_name;
@@ -80,12 +21,6 @@ export default class Service {
     this.createdAt = databaseObject.created;
   }
 
-  /**
-   * Returns the database object of the service.
-   *
-   * @returns {IServiceDatabaseObject} Database object of the service.
-   * @memberof Service
-   */
   public getDatabaseObject(): IServiceDatabaseObject {
     return {
       id: this.id,
@@ -100,11 +35,6 @@ export default class Service {
   }
 }
 
-/**
- * Service database object.
- *
- * @interface ServiceDatabaseObject
- */
 export interface IServiceDatabaseObject {
   id?: number;
   service_name?: string;

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,126 +1,28 @@
 import IUserDatabaseObject from "../interfaces/IUserDatabaseObject";
 import UserRoleString from "../enum/UserRoleString";
 
-/**
- * User object.
- *
- * @export
- * @class User
- */
 export default class User {
-  /**
-   * User id
-   *
-   * @type {number}
-   * @memberof User
-   */
   public id: number;
-  /**
-   * Username
-   *
-   * @type {string}
-   * @memberof User
-   */
   public username: string;
-  /**
-   * Name
-   *
-   * @type {string}
-   * @memberof User
-   */
   public name: string;
-  /**
-   * Screen name
-   *
-   * @type {string}
-   * @memberof User
-   */
   public screenName: string;
-  /**
-   * Email
-   *
-   * @type {string}
-   * @memberof User
-   */
   public email: string;
-  /**
-   * Residence
-   *
-   * @type {string}
-   * @memberof User
-   */
   public residence: string;
-  /**
-   * Phone
-   *
-   * @type {string}
-   * @memberof User
-   */
   public phone: string;
-  /**
-   * Is the user a HYY member or not
-   *
-   * @type {boolean}
-   * @memberof User
-   */
   public isHYYMember: boolean;
-  /**
-   * Membership status
-   *
-   * @type {string}
-   * @memberof User
-   */
   public membership: string;
 
   public role: UserRoleString;
-  /**
-   * Salt
-   *
-   * @type {string}
-   * @memberof User
-   */
   public salt: string;
   /**
    * Password hash (sha1 or BCrypt)
-   *
-   * @type {string}
-   * @memberof User
    */
   public hashedPassword: string;
-  /**
-   * Date when the user was created at.
-   *
-   * @type {Date}
-   * @memberof User
-   */
   public createdAt: Date;
-  /**
-   * Date when the user was last modified.
-   *
-   * @type {Date}
-   * @memberof User
-   */
   public modifiedAt: Date;
-  /**
-   * Is the user a TKTL member or not.
-   *
-   * @type {boolean}
-   * @memberof User
-   */
   public isTKTL: boolean;
-  /**
-   * Is the user deleted or not.
-   *
-   * @type {boolean}
-   * @memberof User
-   */
   public isDeleted: boolean;
 
-  /**
-   * Creates an instance of User.
-   * @param {IUserDatabaseObject} userDatabaseObject User database object
-   * @memberof User
-   */
   constructor(userDatabaseObject: IUserDatabaseObject) {
     this.id = userDatabaseObject.id;
     this.username = userDatabaseObject.username;
@@ -149,12 +51,6 @@ export default class User {
         : Boolean(userDatabaseObject.deleted);
   }
 
-  /**
-   * Removes sensitive information from a user.
-   *
-   * @returns User object with sensitive information removed
-   * @memberof User
-   */
   public removeSensitiveInformation(): User {
     delete this.salt;
     delete this.hashedPassword;
@@ -163,10 +59,6 @@ export default class User {
 
   /**
    * Removes non-requested user data.
-   *
-   * @param {number} dataRequest Data request export number
-   * @returns
-   * @memberof User User with non-requested data removed
    */
   public removeNonRequestedData(dataRequest: number): User {
     Object.keys(this.removeSensitiveInformation()).forEach(
@@ -180,12 +72,6 @@ export default class User {
     return this;
   }
 
-  /**
-   * Returns a database object.
-   *
-   * @returns {IUserDatabaseObject} User database object
-   * @memberof User
-   */
   public getDatabaseObject(): IUserDatabaseObject {
     return {
       id: this.id,

--- a/src/models/UserPayment.ts
+++ b/src/models/UserPayment.ts
@@ -1,32 +1,10 @@
 import { IUserPaymentDatabaseObject } from "../interfaces/IUserDatabaseObject";
 import User from "./User";
-/**
- * User payment.
- *
- * @export
- * @class UserPayment
- * @extends {User}
- */
+
 export class UserPayment extends User {
-  /**
-   * Paid date
-   *
-   * @type {Date}
-   * @memberof UserPayment
-   */
   public paid: Date;
-  /**
-   * Valid until date
-   *
-   * @type {Date}
-   * @memberof UserPayment
-   */
   public valid_until: Date;
-  /**
-   * Creates an instance of UserPayment.
-   * @param {IUserPaymentDatabaseObject} dbEnt
-   * @memberof UserPayment
-   */
+
   constructor(dbEnt: IUserPaymentDatabaseObject) {
     super(dbEnt);
     this.paid = dbEnt.paid;

--- a/src/services/AuthenticationService.ts
+++ b/src/services/AuthenticationService.ts
@@ -6,28 +6,9 @@ import Service, { IServiceDatabaseObject } from "../models/Service";
 import ServiceToken, { stringToServiceToken } from "../token/Token";
 import ServiceError from "../utils/ServiceError";
 
-/**
- * Authentication service.
- *
- * @export
- * @class AuthenticationService
- */
 export default class AuthenticationService {
-  /**
-   * Creates an instance of AuthenticationService.
-   * @param {UserDao} userDao UserDao
-   * @param {ServiceDao} serviceDao ServiceDao
-   * @memberof AuthenticationService
-   */
-  constructor(private readonly serviceDao: ServiceDao) {}
+  constructor(private readonly serviceDao: ServiceDao) { }
 
-  /**
-   * Returns a single service by its name.
-   *
-   * @param {string} serviceName
-   * @returns {Promise<Service>}
-   * @memberof AuthenticationService
-   */
   public async getService(serviceName: string): Promise<Service> {
     const service: IServiceDatabaseObject = await this.serviceDao.findByName(serviceName);
     if (!service) {
@@ -36,13 +17,6 @@ export default class AuthenticationService {
     return new Service(service);
   }
 
-  /**
-   * Returns a single service by its identifier.
-   *
-   * @param {string} service_identifier
-   * @returns {Promise<Service>}
-   * @memberof AuthenticationService
-   */
   public async getServiceWithIdentifier(service_identifier: string): Promise<Service> {
     const service: IServiceDatabaseObject = await this.serviceDao.findByIdentifier(service_identifier);
     if (!service) {
@@ -51,12 +25,6 @@ export default class AuthenticationService {
     return new Service(service);
   }
 
-  /**
-   * Returns all services.
-   *
-   * @returns {Promise<Service[]>}
-   * @memberof AuthenticationService
-   */
   public async getServices(): Promise<Service[]> {
     const services: IServiceDatabaseObject[] = await this.serviceDao.findAll();
 
@@ -65,11 +33,6 @@ export default class AuthenticationService {
 
   /**
    * Appends a new service to the authentication token.
-   *
-   * @param {(string | ServiceToken)} oldToken
-   * @param {string} newServiceName
-   * @returns {string}
-   * @memberof AuthenticationService
    */
   public appendNewServiceAuthenticationToToken(oldToken: string | ServiceToken, newServiceName: string): string {
     let token: ServiceToken;
@@ -92,11 +55,6 @@ export default class AuthenticationService {
 
   /**
    * Remove a service from the authentication token.
-   *
-   * @param {(string | ServiceToken)} oldToken
-   * @param {string} serviceToRemove
-   * @returns {string}
-   * @memberof AuthenticationService
    */
   public removeServiceAuthenticationToToken(oldToken: string | ServiceToken, serviceToRemove: string): string {
     let token: ServiceToken;
@@ -119,28 +77,11 @@ export default class AuthenticationService {
     }
   }
 
-  /**
-   * Creates token.
-   *
-   * @param {number} userId
-   * @param {string[]} authenticatedTo
-   * @returns {string}
-   * @memberof AuthenticationService
-   */
   public createToken(userId: number, authenticatedTo: string[]): string {
     return new ServiceToken(userId, authenticatedTo, new Date()).toString();
   }
 }
 
-/**
- * Validates password.
- *
- * @export
- * @param {string} password
- * @param {string} salt
- * @param {string} hashedPassword
- * @returns {Promise<boolean>}
- */
 export async function validatePassword(password: string, salt: string, hashedPassword: string): Promise<boolean> {
   return await compare(sha1(`${salt}kekbUr${password}`), hashedPassword);
 }

--- a/src/services/ConsentService.ts
+++ b/src/services/ConsentService.ts
@@ -5,28 +5,9 @@ import IService from "../interfaces/IService";
 import Consent from "../models/Consent";
 import ServiceError from "../utils/ServiceError";
 
-/**
- * Consent service.
- *
- * @export
- * @class ConsentService
- * @implements {IService<Consent>}
- */
 export default class ConsentService implements IService<Consent> {
-  /**
-   * Creates an instance of ConsentService.
-   * @param {ConsentDao} consentDao
-   * @memberof ConsentService
-   */
   constructor(private readonly consentDao: ConsentDao) {}
 
-  /**
-   * Finds a single consent.
-   *
-   * @param {number} id Consent ID
-   * @returns {Promise<Consent>} Consent
-   * @memberof ConsentService
-   */
   public async findOne(id: number): Promise<Consent> {
     const consent: IConsentDatabaseObject = await this.consentDao.findOne(id);
     if (!consent) {
@@ -37,10 +18,6 @@ export default class ConsentService implements IService<Consent> {
 
   /**
    * Resets all consents to unknown in a service (That have not been declined.)
-   *
-   * @param {number} service_id Service ID
-   * @returns {Promise<number[]>}
-   * @memberof ConsentService
    */
   public async resetAllAcceptedByService(
     service_id: number
@@ -51,12 +28,6 @@ export default class ConsentService implements IService<Consent> {
     return res;
   }
 
-  /**
-   * Finds all consents.
-   *
-   * @returns {Promise<Consent[]>} All consents
-   * @memberof ConsentService
-   */
   public async findAll(): Promise<Consent[]> {
     const consents: IConsentDatabaseObject[] = await this.consentDao.findAll();
     return consents.map(
@@ -64,38 +35,16 @@ export default class ConsentService implements IService<Consent> {
     );
   }
 
-  /**
-   * Updates a consent.
-   *
-   * @param {number} entity_id Consent ID
-   * @param {Consent} entity Consent
-   * @returns {Promise<boolean>}
-   * @memberof ConsentService
-   */
   public async update(entity_id: number, entity: Consent): Promise<number> {
     const res: number = await this.consentDao.update(entity_id, entity);
     return res;
   }
 
-  /**
-   * Deletes a consent.
-   *
-   * @param {number} entity_id Consent ID
-   * @returns {Promise<boolean>}
-   * @memberof ConsentService
-   */
   public async delete(entity_id: number): Promise<boolean> {
     const res: boolean = await this.consentDao.remove(entity_id);
     return res;
   }
 
-  /**
-   * Creates a consent.
-   *
-   * @param {Consent} entity
-   * @returns {Promise<number[]>}
-   * @memberof ConsentService
-   */
   public async create(entity: Consent): Promise<number[]> {
     const res: number[] = await this.consentDao.save(entity);
     return res;
@@ -104,11 +53,6 @@ export default class ConsentService implements IService<Consent> {
   /**
    * Declines a privacy policy for a service.
    * If a consent's value is undefined, update it to "declined"
-   *
-   * @param {number} user_id User ID
-   * @param {number} service_id Service ID
-   * @returns {Promise<number[]>}
-   * @memberof ConsentService
    */
   public async declineConsent(
     user_id: number,
@@ -149,14 +93,6 @@ export default class ConsentService implements IService<Consent> {
     }
   }
 
-  /**
-   * Finds a consent by user and a service.
-   *
-   * @param {number} user_id User id
-   * @param {number} service_id Service id
-   * @returns {Promise<Consent>}
-   * @memberof ConsentService
-   */
   public async findByUserAndService(
     user_id: number,
     service_id: number
@@ -175,11 +111,6 @@ export default class ConsentService implements IService<Consent> {
    * Accepts a privacy policy for a service.
    * If a consent is declined, throw an error.
    * If a consent is undefined, update it to "accepted"
-   *
-   * @param {number} user_id User ID
-   * @param {number} service_id Service ID
-   * @returns {Promise<number[]>}
-   * @memberof ConsentService
    */
   public async acceptConsent(
     user_id: number,

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -8,27 +8,9 @@ enum PaymentType {
   CashPayment = "kateinen"
 }
 
-/**
- * Payment service.
- *
- * @export
- * @class PaymentService
- */
 export default class PaymentService {
-  /**
-   * Creates an instance of PaymentService.
-   * @param {UserDao} paymentDao PaymentDAO
-   * @memberof PaymentService
-   */
   constructor(private readonly paymentDao: PaymentDao) {}
 
-  /**
-   * Returns a single payment from the database.
-   *
-   * @param {number} paymentId Payment ID
-   * @returns {Promise<Payment>} Single payment
-   * @memberof PaymentService
-   */
   public async fetchPayment(paymentId: number): Promise<Payment> {
     const result: IPayment = await this.paymentDao.findOne(paymentId);
     if (!result) {
@@ -38,35 +20,15 @@ export default class PaymentService {
     return new Payment(result);
   }
 
-  /**
-   * Returns all payments.
-   *
-   * @returns {Promise<Payment[]>} All payments
-   * @memberof PaymentService
-   */
   public async fetchAllPayments(): Promise<Payment[]> {
     const results: IPayment[] = await this.paymentDao.findAll();
     return results.map((result: IPayment) => new Payment(result));
   }
 
-  /**
-   * Returns payments by payer.
-   *
-   * @param {number} payerId Payer ID
-   * @returns {Promise<Payment>} Payment
-   * @memberof PaymentService
-   */
   public async fetchPaymentByPayer(payerId: number): Promise<Payment> {
     return new Payment(await this.paymentDao.findByPayer(payerId));
   }
 
-  /**
-   * Returns valid payment for user.
-   *
-   * @param {number} userId User ID
-   * @returns {Promise<Payment>} Payment
-   * @memberof PaymentService
-   */
   public async fetchValidPaymentForUser(userId: number): Promise<Payment> {
     const result: IPayment = await this.paymentDao.findByPayer(userId, true);
     if (!result) {
@@ -75,62 +37,27 @@ export default class PaymentService {
     return new Payment(result);
   }
 
-  /**
-   * Returns all unpaid payments
-   *
-   * @returns {Promise<PaymentListing>} Payment
-   * @memberof PaymentService
-   */
   public async fetchUnpaidPayments(): Promise<PaymentListing[]> {
     const results: IPaymentListing[] = await this.paymentDao.findUnpaid();
     return results.map((ent: IPaymentListing) => new PaymentListing(ent));
   }
 
-  /**
-   * Creates a payment.
-   *
-   * @param {Payment} payment Payment
-   * @returns {Promise<number>} Inserted payment ID(s)
-   * @memberof PaymentService
-   */
   public async createPayment(payment: Payment): Promise<number[]> {
     return this.paymentDao.save(payment as IPayment);
   }
 
-  /**
-   * Creates a bank payment.
-   *
-   * @param {Payment} payment Payment
-   * @returns {Promise<number>} Inserted id
-   * @memberof PaymentService
-   */
   public async createBankPayment(payment: Payment): Promise<number[]> {
     return this.paymentDao.save(Object.assign({}, payment, {
       payment_type: PaymentType.BankPayment
     }) as IPayment);
   }
 
-  /**
-   * Creates a cash payment.
-   *
-   * @param {Payment} payment Payment
-   * @returns {Promise<number>} Inserted id
-   * @memberof PaymentService
-   */
   public async createCashPayment(payment: Payment): Promise<number[]> {
     return this.paymentDao.save(Object.assign({}, payment, {
       payment_type: PaymentType.CashPayment
     }) as IPayment);
   }
 
-  /**
-   * Updates a payment.
-   *
-   * @param {number} paymentId Payment id
-   * @param {Payment} updatedPayment Updated payment
-   * @returns {Promise<IPayment>}
-   * @memberof PaymentService
-   */
   public async updatePayment(
     paymentId: number,
     updatedPayment: Payment
@@ -138,12 +65,6 @@ export default class PaymentService {
     return this.paymentDao.update(paymentId, updatedPayment as IPayment);
   }
 
-  /**
-   * Finds payments that have been paid by cash.
-   *
-   * @returns {Promise<PaymentListing[]>} List of payments paid by cash.
-   * @memberof PaymentService
-   */
   public async findPaymentsPaidByCash(): Promise<PaymentListing[]> {
     const results: IPaymentListing[] = await this.paymentDao.findPaymentsByPaymentType(
       PaymentType.CashPayment
@@ -151,12 +72,6 @@ export default class PaymentService {
     return results.map((ent: IPaymentListing) => new PaymentListing(ent));
   }
 
-  /**
-   * Finds payments that have been paid by bank transfer.
-   *
-   * @returns {Promise<PaymentListing[]>} List of payments paid by bank transfer.
-   * @memberof PaymentService
-   */
   public async findPaymentsPaidByBankTransfer(): Promise<PaymentListing[]> {
     const results: IPaymentListing[] = await this.paymentDao.findPaymentsByPaymentType(
       PaymentType.BankPayment
@@ -164,23 +79,14 @@ export default class PaymentService {
     return results.map((ent: IPaymentListing) => new PaymentListing(ent));
   }
 
-  /**
-   * Delete payment
-   *
-   * @param {number} paymentId Payment id
-   * @memberof PaymentService
-   */
+  // TODO: Fix typo
   public async deletePatyment(paymentId: number): Promise<void> {
     await this.paymentDao.deletePayment(paymentId);
   }
 
   /**
    * Marks a cash payment paid.
-   *
-   * @param {number} payment_id Payment ID
-   * @param {number} confirmer_id Confirmer ID
-   * @returns {Promise<boolean>} True if the operation succeeded.
-   * @memberof PaymentService
+   * TODO: Clarify naming?
    */
   public async makeCashPaid(
     payment_id: number,
@@ -201,11 +107,7 @@ export default class PaymentService {
 
   /**
    * Marks a bank payment paid.
-   *
-   * @param {number} payment_id Payment ID
-   * @param {number} confirmer_id Confirmer ID
-   * @returns {Promise<boolean>} True if the operation succeeded.
-   * @memberof PaymentService
+   * TODO: Clarify naming?
    */
   public async makeBankPaid(
     payment_id: number,
@@ -233,13 +135,7 @@ export default class PaymentService {
 
   /**
    * Adds a cash payment.
-   *
-   * @param {number} payer_id Payer ID
-   * @param {number} confirmer_id Confirmer ID
-   * @param {number} seasons Number of seasons
-   * @param {string} membership Membership
-   * @returns {Promise<Payment>} Created payment
-   * @memberof PaymentService
+   * TODO: Should this be `createCashPayment` instead?
    */
   public async addCashPayment(
     payer_id: number,

--- a/src/services/PrivacyPolicyService.ts
+++ b/src/services/PrivacyPolicyService.ts
@@ -4,27 +4,9 @@ import IService from "../interfaces/IService";
 import PrivacyPolicy from "../models/PrivacyPolicy";
 import ServiceError from "../utils/ServiceError";
 
-/**
- * Privacy policy service.
- *
- * @export
- * @class PrivacyPolicyService
- * @implements {IService<PrivacyPolicy>}
- */
 export default class PrivacyPolicyService implements IService<PrivacyPolicy> {
-  /**
-   * Creates an instance of PrivacyPolicyService.
-   * @param {PrivacyPolicyDao} privacyPolicyDao Privacy policy DAO
-   * @memberof PrivacyPolicyService
-   */
   constructor(private readonly privacyPolicyDao: PrivacyPolicyDao) {}
-  /**
-   * Finds one privacy policy.
-   *
-   * @param {number} id Privacy policy ID
-   * @returns {Promise<PrivacyPolicy>} Privacy policy
-   * @memberof PrivacyPolicyService
-   */
+
   public async findOne(id: number): Promise<PrivacyPolicy> {
     const res: IPrivacyPolicyDatabaseObject = await this.privacyPolicyDao.findOne(
       id
@@ -35,13 +17,6 @@ export default class PrivacyPolicyService implements IService<PrivacyPolicy> {
     return new PrivacyPolicy(res);
   }
 
-  /**
-   * Finds a privacy policy by service identifier.
-   *
-   * @param {string} serviceIdentifier Service identifier
-   * @returns {Promise<PrivacyPolicy>}
-   * @memberof PrivacyPolicyService
-   */
   public async findByServiceIdentifier(
     serviceIdentifier: string
   ): Promise<PrivacyPolicy> {
@@ -54,43 +29,18 @@ export default class PrivacyPolicyService implements IService<PrivacyPolicy> {
     return new PrivacyPolicy(res);
   }
 
-  /**
-   * Returns all privacy policies.
-   *
-   * @returns {Promise<PrivacyPolicy[]>}
-   * @memberof PrivacyPolicyService
-   */
   public findAll(): Promise<PrivacyPolicy[]> {
     throw new Error("Method not implemented.");
   }
-  /**
-   * Updates a privacy policy.
-   *
-   * @param {number} entity_id Privacy policy ID
-   * @param {PrivacyPolicy} entity Privacy policy
-   * @returns {Promise<number>}
-   * @memberof PrivacyPolicyService
-   */
+
   public update(entity_id: number, entity: PrivacyPolicy): Promise<number> {
     throw new Error("Method not implemented.");
   }
-  /**
-   * Deletes a privacy policy.
-   *
-   * @param {number} entity_id Privacy policy ID
-   * @returns {Promise<boolean>}
-   * @memberof PrivacyPolicyService
-   */
+
   public delete(entity_id: number): Promise<boolean> {
     throw new Error("Method not implemented.");
   }
-  /**
-   * Creates a privacy policy.
-   *
-   * @param {PrivacyPolicy} entity
-   * @returns {Promise<number[]>}
-   * @memberof PrivacyPolicyService
-   */
+
   public create(entity: PrivacyPolicy): Promise<number[]> {
     throw new Error("Method not implemented.");
   }

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -8,26 +8,9 @@ import { UserPayment } from "../models/UserPayment";
 import ServiceError from "../utils/ServiceError";
 import { validatePassword } from "./AuthenticationService";
 
-/**
- * User service.
- *
- * @export
- * @class UserService
- */
 export default class UserService {
-  /**
-   * Creates an instance of UserService.
-   * @param {UserDao} userDao
-   * @memberof UserService
-   */
   constructor(private readonly userDao: UserDao) {}
-  /**
-   * Returns a single user from the database.
-   *
-   * @param {number} userId
-   * @returns
-   * @memberof UserService
-   */
+
   public async fetchUser(userId: number): Promise<User> {
     const result: IUserDatabaseObject = await this.userDao.findOne(userId);
     if (!result) {
@@ -37,34 +20,18 @@ export default class UserService {
     return new User(result);
   }
 
-  /**
-   * Returns all users.
-   *
-   * @returns {Promise<User[]>}
-   * @memberof UserService
-   */
   public async fetchAllUsers(): Promise<User[]> {
     const results: IUserDatabaseObject[] = await this.userDao.findAll();
     return results.map((dbObj: IUserDatabaseObject) => new User(dbObj));
   }
 
-  /**
-   * Returns all unpaid users.
-   *
-   * @returns {Promise<User[]>}
-   * @memberof UserService
-   */
   public async fetchAllUnpaidUsers(): Promise<User[]> {
     const results: IUserDatabaseObject[] = await this.userDao.findAllByUnpaidPayment();
     return results.map((dbObj: IUserDatabaseObject) => new User(dbObj));
   }
 
   /**
-   * Searches all users.
-   *
-   * @param {string} searchTerm
-   * @returns {Promise<User[]>}
-   * @memberof UserService
+   * Searches all users with the given SQL WHERE condition.
    */
   public async searchUsers(searchTerm: string): Promise<User[]> {
     const results: IUserDatabaseObject[] = await this.userDao.findWhere(searchTerm);
@@ -77,11 +44,6 @@ export default class UserService {
 
   /**
    * Fetches users with selected fields and those who match the conditions.
-   *
-   * @param {string[]} fields Fields
-   * @param {string[]} [conditions] Conditions
-   * @returns {Promise<User[]>} List of users.
-   * @memberof UserService
    */
   public async fetchAllWithSelectedFields(fields: string[], conditions?: string[]): Promise<UserPayment[]> {
     let conditionQuery: string[] = null;
@@ -118,14 +80,6 @@ export default class UserService {
     return results.map((u: IUserPaymentDatabaseObject) => new UserPayment(u));
   }
 
-  /**
-   * Returns username with username and password.
-   *
-   * @param {string} username Username
-   * @param {string} password Password
-   * @returns {Promise<User>} User
-   * @memberof UserService
-   */
   public async getUserWithUsernameAndPassword(username: string, password: string): Promise<User> {
     const dbUser: IUserDatabaseObject = await this.userDao.findByUsername(username);
     if (!dbUser) {
@@ -141,38 +95,16 @@ export default class UserService {
     throw new ServiceError(401, "Invalid username or password");
   }
 
-  /**
-   * Checks if username is available.
-   *
-   * @param {string} username
-   * @returns {Promise<boolean>} True if the username is available
-   * @memberof UserService
-   */
   public async checkUsernameAvailability(username: string): Promise<boolean> {
     const user: IUserDatabaseObject = await this.userDao.findByUsername(username);
     return user === undefined;
   }
 
-  /**
-   * Checks if email is available.
-   *
-   * @param {string} email Email address
-   * @returns {Promise<boolean>}
-   * @memberof UserService
-   */
   public async checkEmailAvailability(email: string): Promise<boolean> {
     const user: IUserDatabaseObject = await this.userDao.findByEmail(email);
     return user === undefined;
   }
 
-  /**
-   * Creates an user.
-   *
-   * @param {User} user User object
-   * @param {string} password Password
-   * @returns {Promise<number[]>}
-   * @memberof UserService
-   */
   public async createUser(user: User, rawPassword: string): Promise<number> {
     let newUser: User = new User({});
     const { password, salt } = await mkHashedPassword(rawPassword);
@@ -183,15 +115,6 @@ export default class UserService {
     return insertIds[0];
   }
 
-  /**
-   * Updates an user.
-   *
-   * @param {number} userId User ID
-   * @param {User} udpatedUser User data
-   * @param {string} [password] Password
-   * @returns {Promise<number[]>} Affected rows.
-   * @memberof UserService
-   */
   public async updateUser(userId: number, udpatedUser: User, password?: string): Promise<number> {
     let newUser: User = new User({});
     newUser = Object.assign(newUser, udpatedUser);
@@ -200,13 +123,6 @@ export default class UserService {
     return affectedRows;
   }
 
-  /**
-   * Deletes a user.
-   *
-   * @param {number} userId User ID
-   * @returns {Promise<boolean>}
-   * @memberof UserService
-   */
   public async deleteUser(userId: number): Promise<boolean> {
     return this.userDao.remove(userId);
   }

--- a/src/token/Token.ts
+++ b/src/token/Token.ts
@@ -1,32 +1,13 @@
 import * as JWT from "jsonwebtoken";
 import IParsedTokenContents from "../interfaces/IParsedTokenContents";
 
-/**
- * ServiceToken class.
- *
- * @export
- * @class ServiceToken
- */
 export default class ServiceToken {
-  /**
-   * Creates an instance of ServiceToken.
-   * @param {number} userId User id
-   * @param {string[]} authenticatedTo Service list
-   * @param {Date} createdAt Creation date
-   * @memberof ServiceToken
-   */
   constructor(
     public userId: number,
     public authenticatedTo: string[],
     public createdAt: Date
   ) {}
 
-  /**
-   * Converts the token to a string.
-   *
-   * @returns {string} Token as a string
-   * @memberof ServiceToken
-   */
   public toString(): string {
     try {
       const parsedTokenContents: IParsedTokenContents = {
@@ -41,13 +22,6 @@ export default class ServiceToken {
   }
 }
 
-/**
- * Converts a token string to a ServiceToken.
- *
- * @export
- * @param {string} token Token as string
- * @returns {ServiceToken}
- */
 export function stringToServiceToken(token: string): ServiceToken {
   let parsedToken: string | object = null;
   try {

--- a/src/utils/ApiRoute.ts
+++ b/src/utils/ApiRoute.ts
@@ -4,10 +4,8 @@ import Express from "express";
  * Generates an API route in the format /api/{API_VERSION}/{ENDPOINT_NAME} or /api/{ENDPOINT_NAME}
  * depending on if API version is not set.
  *
- * @export
- * @param {string} endpointName Endpoint name
- * @param {string} [apiVersion] API version. Defaults to null, can be configured manually.
- * @returns {string} API route, example: /api/v1/users
+ * @param apiVersion API version. Defaults to null, can be configured manually.
+ * @returns API route, example: /api/v1/users
  */
 function generateApiRoute(endpointName: string, apiVersion?: string): string {
   if (!apiVersion) {
@@ -16,20 +14,18 @@ function generateApiRoute(endpointName: string, apiVersion?: string): string {
     return "/api/" + apiVersion + "/" + endpointName;
   }
 }
+
 /**
  * API header middleware that sets headers.
- *
- * @param {string} [apiVersion] API version
- * @returns
  */
 function apiHeaderMiddleware(
   apiVersion?: string
 ): (
-  req: Express.Request,
-  res: Express.Response,
-  next: Express.NextFunction
-) => void {
-  return function(
+    req: Express.Request,
+    res: Express.Response,
+    next: Express.NextFunction
+  ) => void {
+  return function (
     req: Express.Request,
     res: Express.Response,
     next: Express.NextFunction

--- a/src/utils/AuthorizeMiddleware.ts
+++ b/src/utils/AuthorizeMiddleware.ts
@@ -5,102 +5,36 @@ import UserService from "../services/UserService";
 import ServiceToken, { stringToServiceToken } from "../token/Token";
 import ServiceResponse from "./ServiceResponse";
 
-/**
- * IASRequest interface.
- *
- * @interface IASRequest
- * @extends {express.Request}
- */
 export interface IASRequest extends express.Request {
-  /**
-   * Authorization data.
-   * @memberof IASRequest
-   */
   authorization: {
-    /**
-     * User
-     *
-     * @type {User}
-     */
     user: User;
-    /**
-     * Service token
-     *
-     * @type {ServiceToken}
-     */
     token: ServiceToken;
   };
 
-  /**
-   * Session
-   *
-   * @type {ISession}
-   */
   session?: ISession;
 }
+
 /**
  * ISession interface adds support for new keys in the Express.Session interface.
- *
- * @interface ISession
- * @extends {Express.Session}
  */
 interface ISession extends Express.Session {
-  /**
-   * User
-   *
-   * @type {ISessionUser}
-   * @memberof ISession
-   */
   user?: ISessionUser;
-  /**
-   * Current login step
-   *
-   * @type {LoginStep}
-   * @memberof ISession
-   */
   loginStep?: LoginStep;
   /**
    * User requested keys
-   *
-   * @type {Array<{ name: string; value: string }>}
-   * @memberof IASRequest
    */
   keys: Array<{ name: string; value: string }>;
 }
 
-/**
- * Login step enum.
- *
- * @export
- * @enum {number}
- */
 export enum LoginStep {
   PrivacyPolicy,
   GDPR,
   Login
 }
 
-/**
- * Authorize middleware.
- *
- * @export
- * @class AuthorizeMiddleware
- */
 export default class AuthorizeMiddleware {
-  /**
-   * Creates an instance of AuthorizeMiddleware.
-   * @param {UserService} userService User service
-   * @memberof AuthorizeMiddleware
-   */
   constructor(private userService: UserService) {}
 
-  /**
-   * Authorizes the user.
-   *
-   * @param {boolean} returnAsJson Return as JSON
-   *
-   * @memberof AuthorizeMiddleware
-   */
   public authorize = (
     returnAsJson: boolean
   ): ((
@@ -168,15 +102,6 @@ export default class AuthorizeMiddleware {
     }
   }
 
-  /**
-   * Loads the token.
-   *
-   * @param {IASRequest} req
-   * @param {express.Response} res
-   * @param {express.NextFunction} next
-   * @returns
-   * @memberof AuthorizeMiddleware
-   */
   public async loadToken(
     req: IASRequest,
     res: express.Response,

--- a/src/utils/CachingMiddleware.ts
+++ b/src/utils/CachingMiddleware.ts
@@ -1,12 +1,9 @@
 import * as Express from "express";
 
 /**
- * Caching middleware.
- * Disables caching.
+ * A middleware which disables caching
  *
- * @param {Express.Request | any} req Express request
- * @param {Express.Response | any} res Express response
- * @param {Express.NextFunction | any} next Express NextFunction
+ * TODO: Remove `any` arguments
  */
 // tslint:disable-next-line:typedef
 const cachingMiddleware = (

--- a/src/utils/ServiceError.ts
+++ b/src/utils/ServiceError.ts
@@ -1,17 +1,4 @@
-/**
- * ServiceError.
- *
- * @export
- * @class ServiceError
- * @extends {Error}
- */
 export default class ServiceError extends Error {
-  /**
-   * Creates an instance of ServiceError.
-   * @param {number} httpErrorCode HTTP error code
-   * @param {string} message Message
-   * @memberof ServiceError
-   */
   constructor(public httpErrorCode: number, message: string) {
     super(message);
   }

--- a/src/utils/ServiceResponse.ts
+++ b/src/utils/ServiceResponse.ts
@@ -1,38 +1,8 @@
-/**
- * Service response.
- *
- * @export
- * @class ServiceResponse
- */
 export default class ServiceResponse<T> {
-  /**
-   * Status of the response.
-   *
-   * @type {boolean}
-   * @memberof ServiceResponse
-   */
   public ok: boolean;
-  /**
-   * Message.
-   *
-   * @type {string} Message
-   * @memberof ServiceResponse
-   */
   public message: string;
-  /**
-   * Payload
-   *
-   * @type {T}
-   * @memberof ServiceResponse
-   */
   public payload: T;
-  /**
-   * Creates an instance of ServiceResponse.
-   * @param {T} payload
-   * @param {string} [message="Success"]
-   * @param {(boolean | null)} [ok=null]
-   * @memberof ServiceResponse
-   */
+
   constructor(
     payload: T,
     message: string = "Success",

--- a/src/utils/UserHelpers.ts
+++ b/src/utils/UserHelpers.ts
@@ -1,13 +1,6 @@
 import { RoleNumbers } from "../models/User";
 import UserRoleString from "../enum/UserRoleString";
 
-/**
- * Converts a string representation to a boolean.
- *
- * @export
- * @param {*} str String representation
- * @returns {boolean} Boolean
- */
 export function stringToBoolean(str: string | number | object | boolean): boolean {
   return str === "0"
     ? false
@@ -20,14 +13,6 @@ export function stringToBoolean(str: string | number | object | boolean): boolea
           : false;
 }
 
-/**
- * Compares user roles.
- *
- * @export
- * @param {string} a Role a
- * @param {string} b Role b
- * @returns {number} Role difference
- */
 export function compareRoles(a: UserRoleString, b: UserRoleString): number {
   let aN: number = 0;
   let bN: number = 0;

--- a/src/validators/PaymentValidator.ts
+++ b/src/validators/PaymentValidator.ts
@@ -3,21 +3,8 @@ import Payment from "../models/Payment";
 import User from "../models/User";
 import ServiceError from "../utils/ServiceError";
 
-/**
- * Payment validator.
- *
- * @export
- * @class PaymentValidator
- * @implements {IValidator<Payment>}
- */
 export default class PaymentValidator implements IValidator<Payment> {
 
-  /**
-   * Validates payment creation.
-   *
-   * @param {Payment} bodyData Payment data
-   * @memberof PaymentValidator
-   */
   public validateCreate(bodyData: Payment): void {
     if (
       !bodyData.payer_id ||
@@ -35,15 +22,6 @@ export default class PaymentValidator implements IValidator<Payment> {
     bodyData.created = new Date();
   }
 
-  /**
-   * Validates payment update.
-   *
-   * @param {number} dataId Data ID
-   * @param {Payment} newData Payment data
-   * @param {User} validator User
-   * @returns {void}
-   * @memberof PaymentValidator
-   */
   public validateUpdate(dataId: number, newData: Payment, validator: User): void {
     return;
   }

--- a/src/validators/UserValidator.ts
+++ b/src/validators/UserValidator.ts
@@ -6,32 +6,12 @@ import UserService from "../services/UserService";
 import ServiceError from "../utils/ServiceError";
 import { stringToBoolean } from "../utils/UserHelpers";
 
-/**
- * Additional user data.
- *
- * @interface IAdditionalUserData
- */
 export interface IAdditionalUserData {
-  /**
-   * Password.
-   *
-   * @type {string} Password
-   * @memberof IAdditionalUserData
-   */
   password1: string;
   /**
    * Password (typed again).
-   *
-   * @type {string} Password
-   * @memberof IAdditionalUserData
    */
   password2: string;
-  /**
-   * Is the user deleted or not.
-   *
-   * @type {boolean}
-   * @memberof IAdditionalUserData
-   */
   deleted: boolean;
 }
 
@@ -53,27 +33,9 @@ const allowedJVEdit: string[] = [...allowedSelfEdit, "name", "username", "member
 // Colums allowed to be edited by admin
 const allowedAdminEdit: string[] = [...allowedJVEdit, "role", "createdAt"];
 
-/**
- * User validator.
- *
- * @export
- * @class UserValidator
- * @implements {IValidator<User>}
- */
 export default class UserValidator implements IValidator<User> {
-  /**
-   * Creates an instance of UserValidator.
-   * @param {UserService} userService
-   * @memberof UserValidator
-   */
   constructor(private userService: UserService) { }
 
-  /**
-   * Validates user creation.
-   *
-   * @param {(User & IAdditionalUserData)} newUser
-   * @memberof UserValidator
-   */
   public async validateCreate(
     newUser: User & IAdditionalUserData
   ): Promise<void> {
@@ -114,16 +76,6 @@ export default class UserValidator implements IValidator<User> {
     }
   }
 
-  /**
-   * Validates user update.
-   *
-   * @param {number} userId User ID
-   * @param {(User & IAdditionalUserData)} newUser User data
-   * @param {User} modifier Modifier
-   * @returns {Promise<void>}
-   * @throws {ServiceError}
-   * @memberof UserValidator
-   */
   public async validateUpdate(
     userId: number,
     newUser: User & IAdditionalUserData,
@@ -181,13 +133,6 @@ export default class UserValidator implements IValidator<User> {
     }
   }
 
-  /**
-   * Checks for username availability.
-   *
-   * @param {User} newUser User object
-   * @returns {Promise<void>}
-   * @throws {ServiceError}
-   */
   public async checkUsernameAvailability(newUser: User): Promise<void> {
     if (newUser.username) {
       // Test username
@@ -200,13 +145,6 @@ export default class UserValidator implements IValidator<User> {
     }
   }
 
-  /**
-   * Checks for email availability.
-   *
-   * @param {User} newUser User object
-   * @returns {Promise<void>}
-   * @throws {ServiceError}
-   */
   public async checkEmailAvailability(newUser: User): Promise<void> {
     if (newUser.email) {
       // Test email
@@ -219,14 +157,6 @@ export default class UserValidator implements IValidator<User> {
     }
   }
 
-  /**
-   * Checks for email address validity.
-   *
-   * @private
-   * @param {string} email Email address
-   * @returns {boolean} True if the email is valid
-   * @memberof UserValidator
-   */
   public checkEmailValidity(email: string): boolean {
     if (
       !email ||
@@ -243,13 +173,6 @@ export default class UserValidator implements IValidator<User> {
   }
 }
 
-/**
- * Checks modify permission.
- *
- * @param {User} user User
- * @param {string[]} allowedEdits Allowed edits
- * @throws {ServiceError}
- */
 export function checkModifyPermission(
   user: User,
   allowedEdits: string[]


### PR DESCRIPTION
Removes unnecessary jsdoc annotations for most places along with non-informative docblock contents. I tried to be as lax as possible with comment preservation and only removed documentation text for places where they just repeated the function name and kept other comments intact. The docblocks are a source of confusion since they repeate information available from the type annotations and are hard to keep in sync. With no added information in most cases they hinder the readability of the codebase.