### PR TITLE
Implement authentication for services without user token

### DIFF
--- a/src/utils/AuthorizeMiddleware.ts
+++ b/src/utils/AuthorizeMiddleware.ts
@@ -39,15 +39,15 @@ class AuthorizeMiddleware {
     (returnAsJson: boolean): ((req: IASRequest, res: express.Response, next: express.NextFunction) => void) =>
     async (req: IASRequest, res: express.Response, next: express.NextFunction): Promise<express.Response | void> => {
       const headerValue = req.get("authorization");
-      console.log('header', headerValue);
+      console.log("header", headerValue);
       if (headerValue && headerValue.toString().startsWith("Bearer ")) {
         const authValue = headerValue.slice(7).toString();
 
-        if (authValue.startsWith('service:')) {
-          const [,serviceId,secret] = authValue.split(':', 3);
+        if (authValue.startsWith("service:")) {
+          const [, serviceId, secret] = authValue.split(":", 3);
           const service = await AuthenticationService.getServiceWithIdentifier(serviceId);
 
-          console.log('Secret', service.secret, secret);
+          console.log("Secret", service.secret, secret);
 
           if (service.secret !== secret) {
             if (returnAsJson) {
@@ -64,25 +64,25 @@ class AuthorizeMiddleware {
             user: new User({
               id: -1,
               username: serviceId,
-              name: '',
-              screen_name: '', 
-              email: '',
-              residence: '',
-              phone: '', 
+              name: "",
+              screen_name: "",
+              email: "",
+              residence: "",
+              phone: "",
               hyy_member: 1,
-              membership: 'kunniajasen',
-              role: 'yllapitaja',
-              salt: '',
-              hashed_password: '',
-              password_hash: '', 
+              membership: "kunniajasen",
+              role: "yllapitaja",
+              salt: "",
+              hashed_password: "",
+              password_hash: "",
               created: new Date(),
-              modified: new Date(), 
-              tktl: 1, 
+              modified: new Date(),
+              tktl: 1,
               deleted: 0,
               hy_staff: 1,
               hy_student: 1,
             }),
-          }
+          };
 
           return next();
         }

--- a/src/utils/AuthorizeMiddleware.ts
+++ b/src/utils/AuthorizeMiddleware.ts
@@ -5,6 +5,7 @@ import User from "../models/User";
 import UserService from "../services/UserService";
 import ServiceToken, { stringToServiceToken } from "../token/Token";
 import ServiceResponse from "./ServiceResponse";
+import AuthenticationService from "../services/AuthenticationService";
 
 export enum LoginStep {
   PrivacyPolicy,
@@ -37,10 +38,57 @@ class AuthorizeMiddleware {
   public authorize =
     (returnAsJson: boolean): ((req: IASRequest, res: express.Response, next: express.NextFunction) => void) =>
     async (req: IASRequest, res: express.Response, next: express.NextFunction): Promise<express.Response | void> => {
-      const token = req.get("authorization");
-      if (token && token.toString().startsWith("Bearer ")) {
+      const headerValue = req.get("authorization");
+      console.log('header', headerValue);
+      if (headerValue && headerValue.toString().startsWith("Bearer ")) {
+        const authValue = headerValue.slice(7).toString();
+
+        if (authValue.startsWith('service:')) {
+          const [,serviceId,secret] = authValue.split(':', 3);
+          const service = await AuthenticationService.getServiceWithIdentifier(serviceId);
+
+          console.log('Secret', service.secret, secret);
+
+          if (service.secret !== secret) {
+            if (returnAsJson) {
+              return res.status(403).json(new ServiceResponse(null, "Invalid credentials."));
+            } else {
+              return res.status(403).render("serviceError", {
+                error: "Invalid credentials.",
+              });
+            }
+          }
+
+          req.authorization = {
+            token: new ServiceToken(-1, [serviceId], new Date()),
+            user: new User({
+              id: -1,
+              username: serviceId,
+              name: '',
+              screen_name: '', 
+              email: '',
+              residence: '',
+              phone: '', 
+              hyy_member: 1,
+              membership: 'kunniajasen',
+              role: 'yllapitaja',
+              salt: '',
+              hashed_password: '',
+              password_hash: '', 
+              created: new Date(),
+              modified: new Date(), 
+              tktl: 1, 
+              deleted: 0,
+              hy_staff: 1,
+              hy_student: 1,
+            }),
+          }
+
+          return next();
+        }
+
         try {
-          const parsedToken = stringToServiceToken(token.slice(7).toString());
+          const parsedToken = stringToServiceToken(authValue);
           const user = await UserService.fetchUser(parsedToken.userId);
           req.authorization = {
             token: parsedToken,

--- a/src/utils/AuthorizeMiddleware.ts
+++ b/src/utils/AuthorizeMiddleware.ts
@@ -43,7 +43,7 @@ class AuthorizeMiddleware {
       if (headerValue) {
         const [authType, authValue] = headerValue.split(/\s+/, 2);
 
-        if (authType.toLowerCase() === 'bearer') {
+        if (authType.toLowerCase() === "bearer") {
           try {
             const parsedToken = stringToServiceToken(authValue);
             const user = await UserService.fetchUser(parsedToken.userId);
@@ -61,9 +61,9 @@ class AuthorizeMiddleware {
               });
             }
           }
-        } else if (authType.toLowerCase() === 'basic') {
-          const decoded = Buffer.from(authValue, 'base64').toString('utf-8');
-          const [serviceId, secret] = decoded.split(':', 2);
+        } else if (authType.toLowerCase() === "basic") {
+          const decoded = Buffer.from(authValue, "base64").toString("utf-8");
+          const [serviceId, secret] = decoded.split(":", 2);
 
           const service = await AuthenticationService.getServiceWithIdentifier(serviceId);
 
@@ -104,7 +104,6 @@ class AuthorizeMiddleware {
 
           return next();
         }
-
       } else if (headerValue && headerValue.toString().startsWith("Basic ")) {
       } else if (req.cookies.token) {
         try {

--- a/src/utils/AuthorizeMiddleware.ts
+++ b/src/utils/AuthorizeMiddleware.ts
@@ -39,15 +39,13 @@ class AuthorizeMiddleware {
     (returnAsJson: boolean): ((req: IASRequest, res: express.Response, next: express.NextFunction) => void) =>
     async (req: IASRequest, res: express.Response, next: express.NextFunction): Promise<express.Response | void> => {
       const headerValue = req.get("authorization");
-      console.log("header", headerValue);
+
       if (headerValue && headerValue.toString().startsWith("Bearer ")) {
         const authValue = headerValue.slice(7).toString();
 
         if (authValue.startsWith("service:")) {
           const [, serviceId, secret] = authValue.split(":", 3);
           const service = await AuthenticationService.getServiceWithIdentifier(serviceId);
-
-          console.log("Secret", service.secret, secret);
 
           if (service.secret !== secret) {
             if (returnAsJson) {


### PR DESCRIPTION
Services can now authenticate with the API using basic auth, with the service identifier as the username and the service seecret as the password. Requests authenticated this way are handled as if they were made using an user token with the role `yllapitaja`.